### PR TITLE
Make sure errors propagate and stop all tasks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,8 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JET", "Test"]
+test = ["Aqua", "JET", "Logging", "Test"]

--- a/src/ChunkedCSV.jl
+++ b/src/ChunkedCSV.jl
@@ -11,7 +11,6 @@ using Dates
 using FixedPointDecimals
 using TimeZones
 
-# IDEA: We could make a 48bit PosLen string type (8MB -> 23 bits if we represent 8MB as 0, 2 bits for metadata)
 # IDEA: Instead of having SoA layout in TaskResultBuffer, we could try AoS using "reinterpretable bytes"
 
 const MIN_TASK_SIZE_IN_BYTES = 16 * 1024
@@ -22,7 +21,7 @@ include("TaskResults.jl")
 include("fixed_decimals_utils.jl")
 include("datetime_utils.jl")
 
-# Temporaty hack to register new DateTime
+# Temporary hack to register new DateTime
 function __init__()
     Dates.CONVERSION_TRANSLATIONS[_GuessDateTime] = Dates.CONVERSION_TRANSLATIONS[Dates.DateTime]
     nothing

--- a/src/parser_doublebuffer.jl
+++ b/src/parser_doublebuffer.jl
@@ -59,7 +59,7 @@ function process_and_consume_task(parsing_queue::Threads.Channel{T}, parsing_ctx
         # If there was an exception, immediately stop processing the queue
         close(parsing_queue, e)
 
-        # if the io_task was waiting for work to finish, it we'll interrupt it here
+        # if the io_task was waiting for work to finish, we'll interrupt it here
         @lock parsing_ctx.cond.cond_wait begin
             notify(parsing_ctx.cond.cond_wait, e, all=true, error=true)
         end

--- a/src/parser_serial.jl
+++ b/src/parser_serial.jl
@@ -12,6 +12,6 @@ function _parse_file_serial(io, parsing_ctx::ParsingContext, consume_ctx::Abstra
         done && break
         (last_newline_at, quoted, done) = read_and_lex!(io, parsing_ctx, options, byteset, last_newline_at, quoted)
         limit_eols!(parsing_ctx, row_num) && break
-    end # while !done
+    end # while true
     return nothing
 end

--- a/src/parser_singlebuffer.jl
+++ b/src/parser_singlebuffer.jl
@@ -48,7 +48,7 @@ function process_and_consume_task(parsing_queue::Threads.Channel, parsing_ctx::P
         # If there was an exception, immediately stop processing the queue
         close(parsing_queue, e)
 
-        # if the io/lexing was waiting for work to finish, it we'll interrupt it here
+        # if the io/lexing was waiting for work to finish, we'll interrupt it here
         @lock parsing_ctx.cond.cond_wait begin
             notify(parsing_ctx.cond.cond_wait, e, all=true, error=true)
         end

--- a/src/parser_singlebuffer.jl
+++ b/src/parser_singlebuffer.jl
@@ -1,33 +1,25 @@
-function _parse_file_singlebuffer(io, parsing_ctx::ParsingContext, consume_ctx::AbstractConsumeContext, options::Parsers.Options, last_newline_at::UInt32, quoted::Bool, done::Bool, ::Val{N}, ::Val{M}, byteset::Val{B}) where {N,M,B}
+function read_and_lex_task!(parsing_queue::Channel, io, parsing_ctx::ParsingContext, options::Parsers.Options, byteset, last_newline_at, quoted, done)
     row_num = UInt32(1)
-    queue = Channel{Tuple{UInt32,UInt32,UInt32}}(Inf)
-    parser_tasks = Task[]
-    for i in 1:parsing_ctx.nworkers
-        result_buf = TaskResultBuffer{N}(parsing_ctx.schema, cld(length(parsing_ctx.eols), parsing_ctx.maxtasks))
-        t = Threads.@spawn process_and_consume_task(queue, parsing_ctx, options, result_buf, consume_ctx)
-        push!(parser_tasks, t)
-        if i < parsing_ctx.nworkers
-            consume_ctx = maybe_deepcopy(consume_ctx)
-        end
-    end
-    while true
-        # Updates eols_buf with new newlines, byte buffer was updated either from initialization stage or at the end of the loop
+    @inbounds while true
         limit_eols!(parsing_ctx, row_num) && break
         task_size = estimate_task_size(parsing_ctx)
         ntasks = cld(length(parsing_ctx.eols), task_size)
 
+        # Set the expected number of parsing tasks
         @lock parsing_ctx.cond.cond_wait begin
             parsing_ctx.cond.ntasks = ntasks
         end
 
+        # Send task definitions (segmenf of `eols` to process) to the queue
         task_start = UInt32(1)
         for task in Iterators.partition(parsing_ctx.eols, task_size)
             task_end = task_start + UInt32(length(task)) - UInt32(1)
-            put!(queue, (task_start, task_end, row_num))
+            put!(parsing_queue, (task_start, task_end, row_num))
             row_num += UInt32(length(task) - 1)
             task_start = task_end + UInt32(1)
         end
 
+        # Wait for parsers to finish processing current chunk
         @lock parsing_ctx.cond.cond_wait begin
             while true
                 parsing_ctx.cond.ntasks == 0 && break
@@ -37,13 +29,6 @@ function _parse_file_singlebuffer(io, parsing_ctx::ParsingContext, consume_ctx::
         done && break
         (last_newline_at, quoted, done) = read_and_lex!(io, parsing_ctx, options, byteset, last_newline_at, quoted)
     end # while !done
-    # Cleanup
-    for _ in 1:parsing_ctx.nworkers
-        put!(queue, (UInt32(0), UInt32(0), UInt32(0)))
-    end
-    foreach(wait, parser_tasks)
-    close(queue)
-    return nothing
 end
 
 function process_and_consume_task(parsing_queue::Threads.Channel, parsing_ctx::ParsingContext, options::Parsers.Options, result_buf::TaskResultBuffer, consume_ctx::AbstractConsumeContext)
@@ -68,4 +53,31 @@ function process_and_consume_task(parsing_queue::Threads.Channel, parsing_ctx::P
             notify(parsing_ctx.cond.cond_wait, e, all=true, error=true)
         end
     end
+end
+
+function _parse_file_singlebuffer(io, parsing_ctx::ParsingContext, consume_ctx::AbstractConsumeContext, options::Parsers.Options, last_newline_at::UInt32, quoted::Bool, done::Bool, ::Val{N}, ::Val{M}, byteset::Val{B}) where {N,M,B}
+    parsing_queue = Channel{Tuple{UInt32,UInt32,UInt32}}(Inf)
+    parser_tasks = Task[]
+    for i in 1:parsing_ctx.nworkers
+        result_buf = TaskResultBuffer{N}(parsing_ctx.schema, cld(length(parsing_ctx.eols), parsing_ctx.maxtasks))
+        t = Threads.@spawn process_and_consume_task(parsing_queue, parsing_ctx, options, result_buf, consume_ctx)
+        push!(parser_tasks, t)
+        if i < parsing_ctx.nworkers
+            consume_ctx = maybe_deepcopy(consume_ctx)
+        end
+    end
+    try
+        io_task = Threads.@spawn read_and_lex_task!(parsing_queue, io, parsing_ctx, options, byteset, last_newline_at, quoted, done)
+        wait(io_task)
+    catch e
+        close(parsing_queue, e)
+        rethrow()
+    end
+    # Cleanup
+    for _ in 1:parsing_ctx.nworkers
+        put!(parsing_queue, (UInt32(0), UInt32(0), UInt32(0)))
+    end
+    foreach(wait, parser_tasks)
+    close(parsing_queue)
+    return nothing
 end

--- a/src/parser_singlebuffer.jl
+++ b/src/parser_singlebuffer.jl
@@ -28,7 +28,7 @@ function read_and_lex_task!(parsing_queue::Channel, io, parsing_ctx::ParsingCont
         end
         done && break
         (last_newline_at, quoted, done) = read_and_lex!(io, parsing_ctx, options, byteset, last_newline_at, quoted)
-    end # while !done
+    end # while true
 end
 
 function process_and_consume_task(parsing_queue::Threads.Channel, parsing_ctx::ParsingContext, options::Parsers.Options, result_buf::TaskResultBuffer, consume_ctx::AbstractConsumeContext)

--- a/test/exception_handling.jl
+++ b/test/exception_handling.jl
@@ -1,0 +1,67 @@
+using Test
+using Logging
+using .Threads
+using ChunkedCSV
+using ChunkedCSV: TaskResultBuffer, ParsingContext
+
+struct TestThrowingContext <: AbstractConsumeContext end
+
+const throw_ctx = TestThrowingContext()
+function ChunkedCSV.consume!(task_buf::TaskResultBuffer{N}, parsing_ctx::ParsingContext, row_num::UInt32, ctx::TestThrowingContext) where N
+    error("These contexts are for throwing, and that's all what they do")
+end
+
+@testset "exception_handling" begin
+    @testset "serial" begin
+        test_logger = TestLogger(catch_exceptions=true);
+        with_logger(test_logger) do
+            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                a,b
+                1,2
+                3,4
+                """),
+                [Int,Int],
+                throw_ctx,
+                _force=:serial,
+            )
+        end
+    end
+
+    @testset "singlebuffer" begin
+        test_logger = TestLogger(catch_exceptions=true);
+        with_logger(test_logger) do
+            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                a,b
+                1,2
+                3,4
+                """),
+                [Int,Int],
+                throw_ctx,
+                nworkers=nthreads(),
+                _force=:singlebuffer,
+            )
+        end
+        @test length(test_logger.logs) == nthreads()
+        @test test_logger.logs[1].message == "Task failed"
+        @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
+    end
+
+    @testset "doublebuffer" begin
+        test_logger = TestLogger(catch_exceptions=true);
+        with_logger(test_logger) do
+            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                a,b
+                1,2
+                3,4
+                """),
+                [Int,Int],
+                throw_ctx,
+                nworkers=nthreads(),
+                _force=:doublebuffer,
+            )
+        end
+        @test length(test_logger.logs) == nthreads()
+        @test test_logger.logs[1].message == "Task failed"
+        @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
+    end
+end

--- a/test/exception_handling.jl
+++ b/test/exception_handling.jl
@@ -5,63 +5,131 @@ using ChunkedCSV
 using ChunkedCSV: TaskResultBuffer, ParsingContext
 
 struct TestThrowingContext <: AbstractConsumeContext end
+struct ThrowingIO <: IO
+    io::IOBuffer
+end
+ThrowingIO(s::String) = ThrowingIO(IOBuffer(s))
+ChunkedCSV.readbytesall!(io::ThrowingIO, buf, n) = io.io.ptr > 3 ? error("That should be enough data for everyone") : ChunkedCSV.readbytesall!(io.io, buf, n)
+Base.eof(io::ThrowingIO) = Base.eof(io.io)
+
 
 const throw_ctx = TestThrowingContext()
 function ChunkedCSV.consume!(task_buf::TaskResultBuffer{N}, parsing_ctx::ParsingContext, row_num::UInt32, ctx::TestThrowingContext) where N
     error("These contexts are for throwing, and that's all what they do")
 end
 
-@testset "exception_handling" begin
-    @testset "serial" begin
-        test_logger = TestLogger(catch_exceptions=true);
-        with_logger(test_logger) do
-            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
-                a,b
-                1,2
-                3,4
-                """),
-                [Int,Int],
-                throw_ctx,
-                _force=:serial,
-            )
+@testset "Exception Handling" begin
+    @testset "consume!" begin
+        @testset "serial" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    throw_ctx,
+                    _force=:serial,
+                )
+            end
+        end
+
+        @testset "singlebuffer" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    throw_ctx,
+                    nworkers=nthreads(),
+                    _force=:singlebuffer,
+                )
+                sleep(0.2)
+            end
+            @test length(test_logger.logs) == nthreads()
+            @test test_logger.logs[1].message == "Task failed"
+            @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
+        end
+
+        @testset "doublebuffer" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    throw_ctx,
+                    nworkers=nthreads(),
+                    _force=:doublebuffer,
+                )
+                sleep(0.2)
+            end
+            @test length(test_logger.logs) == nthreads()
+            @test test_logger.logs[1].message == "Task failed"
+            @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
         end
     end
 
-    @testset "singlebuffer" begin
-        test_logger = TestLogger(catch_exceptions=true);
-        with_logger(test_logger) do
-            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
-                a,b
-                1,2
-                3,4
-                """),
-                [Int,Int],
-                throw_ctx,
-                nworkers=nthreads(),
-                _force=:singlebuffer,
-            )
+    @testset "io" begin
+        @testset "serial" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "That should be enough data for everyone" parse_file(ThrowingIO("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    ChunkedCSV.SkipContext(),
+                    _force=:serial,
+                )
+            end
         end
-        @test length(test_logger.logs) == nthreads()
-        @test test_logger.logs[1].message == "Task failed"
-        @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
-    end
 
-    @testset "doublebuffer" begin
-        test_logger = TestLogger(catch_exceptions=true);
-        with_logger(test_logger) do
-            @test_throws "These contexts are for throwing, and that's all what they do" parse_file(IOBuffer("""
-                a,b
-                1,2
-                3,4
-                """),
-                [Int,Int],
-                throw_ctx,
-                nworkers=nthreads(),
-                _force=:doublebuffer,
-            )
+        @testset "singlebuffer" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "That should be enough data for everyone" parse_file(ThrowingIO("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    ChunkedCSV.SkipContext(),
+                    nworkers=nthreads(),
+                    _force=:singlebuffer,
+                )
+                sleep(0.2)
+            end
+            @test length(test_logger.logs) == nthreads()
+            @test test_logger.logs[1].message == "Task failed"
+            @test test_logger.logs[1].kwargs[1][1].task.result.msg == "That should be enough data for everyone"
         end
-        @test length(test_logger.logs) == nthreads()
-        @test test_logger.logs[1].message == "Task failed"
-        @test test_logger.logs[1].kwargs[1][1].msg == "These contexts are for throwing, and that's all what they do"
+
+        @testset "doublebuffer" begin
+            test_logger = TestLogger(catch_exceptions=true);
+            with_logger(test_logger) do
+                @test_throws "That should be enough data for everyone" parse_file(ThrowingIO("""
+                    a,b
+                    1,2
+                    3,4
+                    """),
+                    [Int,Int],
+                    ChunkedCSV.SkipContext(),
+                    nworkers=nthreads(),
+                    _force=:doublebuffer,
+                )
+                sleep(0.2)
+            end
+            @test length(test_logger.logs) == nthreads()
+            @test test_logger.logs[1].message == "Task failed"
+            @test test_logger.logs[1].kwargs[1][1].task.result.msg == "That should be enough data for everyone"
+        end
     end
 end

--- a/test/exception_handling.jl
+++ b/test/exception_handling.jl
@@ -9,7 +9,7 @@ struct ThrowingIO <: IO
     io::IOBuffer
 end
 ThrowingIO(s::String) = ThrowingIO(IOBuffer(s))
-ChunkedCSV.readbytesall!(io::ThrowingIO, buf, n) = io.io.ptr > 3 ? error("That should be enough data for everyone") : ChunkedCSV.readbytesall!(io.io, buf, n)
+ChunkedCSV.readbytesall!(io::ThrowingIO, buf, n) = io.io.ptr > 6 ? error("That should be enough data for everyone") : ChunkedCSV.readbytesall!(io.io, buf, n)
 Base.eof(io::ThrowingIO) = Base.eof(io.io)
 
 
@@ -88,6 +88,7 @@ end
                     [Int,Int],
                     ChunkedCSV.SkipContext(),
                     _force=:serial,
+                    buffersize=4,
                 )
             end
         end
@@ -104,6 +105,7 @@ end
                     ChunkedCSV.SkipContext(),
                     nworkers=nthreads(),
                     _force=:singlebuffer,
+                    buffersize=4,
                 )
                 sleep(0.2)
             end
@@ -124,6 +126,7 @@ end
                     ChunkedCSV.SkipContext(),
                     nworkers=nthreads(),
                     _force=:doublebuffer,
+                    buffersize=4,
                 )
                 sleep(0.2)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test
+
 @testset "ChunkedCSV.jl" begin
     include("decimals.jl")
     include("simple_file_parsing.jl")
+    include("exception_handling.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,10 @@
 using Test
 
+Threads.nthreads() == 1 && @warn "Running tests with a single thread -- won't be able to spot concurrency issues"
+
 @testset "ChunkedCSV.jl" begin
     include("decimals.jl")
     include("simple_file_parsing.jl")
     include("exception_handling.jl")
 end
+

--- a/test/simple_file_parsing.jl
+++ b/test/simple_file_parsing.jl
@@ -18,8 +18,6 @@ function ChunkedCSV.consume!(task_buf::TaskResultBuffer{N}, parsing_ctx::Parsing
     end
 end
 
-Threads.nthreads() == 1 && @warn "Running tests with a single thread -- won't be able to spot concurency issues"
-
 @testset "Simple file parsing" begin
     @testset "simple file, single chunk" begin
         for alg in [:serial, :singlebuffer, :doublebuffer]


### PR DESCRIPTION
This ensures that when any error happens in single/double buffered parsing, we don't leave any spawn task running past the lifetime of `parse_file`.

When an exception is thrown in a parser/consume task, we close the work queue channel and `error_notify` the waiting condition for io/lexing task. Touching the closed `Channel` eventually kills all the other parsing workers. The error notification takes care of the lexing task iff it was in a waiting state at the time of the exception.

When an exception is thrown in io/lexing task, we only have to close the channel.