### PR TITLE
DateTime tweaks

### DIFF
--- a/src/datetime_utils.jl
+++ b/src/datetime_utils.jl
@@ -7,86 +7,91 @@ Dates.default_format(::Type{_GuessDateTime}) = Dates.default_format(Dates.DateTi
 Parsers.default_format(::Type{_GuessDateTime}) = Parsers.default_format(Dates.DateTime)
 Dates.validargs(::Type{_GuessDateTime}, vals...) = Dates.validargs(Dates.DateTime, vals...)
 
+function _unsafe_datetime(y=0, m=1, d=1, h=0, mi=0, s=0, ms=0)
+    rata = ms + 1000 * (s + 60mi + 3600h + 86400 * Dates.totaldays(y, m, d))
+    return DateTime(Dates.UTM(rata))
+end
+
 # [y]yyy-[m]m-[d]d(T|\s)HH:MM:SS(\.s{1,3}})?(zzzz|ZZZ|\Z)?
 Base.@propagate_inbounds function _default_tryparse_timestamp(buf, pos, len, code, b, options)
     # ensure there is enough room for at least yyyy-mm-dd
-    len - pos < 9 && (return DateTime(0), code | Parsers.INVALID | Parsers.EOF, len)
+    len - pos < 9 && (return _unsafe_datetime(0), code | Parsers.INVALID | Parsers.EOF, len)
     year = 0
     for i in 1:4
         b -= 0x30
-        b > 0x09 && (return DateTime(0), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(0), code | Parsers.INVALID, pos)
         year = Int(b) + 10 * year
         b = buf[pos += 1]
         (i > 2 && b == UInt8('-')) && break
     end
-    b != UInt8('-')  && (return DateTime(year), code | Parsers.INVALID, pos)
+    b != UInt8('-')  && (return _unsafe_datetime(year), code | Parsers.INVALID, pos)
     b = buf[pos += 1]
 
     month = 0
     for _ in 1:2
         b -= 0x30
-        b > 0x09 && (return DateTime(year), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(year), code | Parsers.INVALID, pos)
         month = Int(b) + 10 * month
         b = buf[pos += 1]
         b == UInt8('-') && break
     end
-    month > 12 && (return DateTime(year), code | Parsers.INVALID, pos)
-    b != UInt8('-')  && (return DateTime(year, month), code | Parsers.INVALID, pos)
+    month > 12 && (return _unsafe_datetime(year), code | Parsers.INVALID, pos)
+    b != UInt8('-')  && (return _unsafe_datetime(year, month), code | Parsers.INVALID, pos)
     b = buf[pos += 1]
 
     day = 0
     for _ in 1:2
         b -= 0x30
-        b > 0x09 && (return DateTime(year, month), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(year, month), code | Parsers.INVALID, pos)
         day = Int(b) + 10 * day
         pos == len && (code |= Parsers.EOF; break)
         b = buf[pos += 1]
         (b == UInt8('T') ||  b == UInt8(' ')) && break
     end
-    day > Dates.daysinmonth(year, month) && (return DateTime(year, month), code | Parsers.INVALID, pos)
-    (pos == len || (b != UInt8('T') && b != UInt8(' '))) && (return DateTime(year, month, day), code | Parsers.OK, pos)
+    day > Dates.daysinmonth(year, month) && (return _unsafe_datetime(year, month), code | Parsers.INVALID, pos)
+    (pos == len || (b != UInt8('T') && b != UInt8(' '))) && (return _unsafe_datetime(year, month, day), code | Parsers.OK, pos)
     # ensure there is enough room for at least HH:MM:DD
-    len - pos < 8 && (return DateTime(0), code | Parsers.INVALID | Parsers.EOF, len)
+    len - pos < 8 && (return _unsafe_datetime(0), code | Parsers.INVALID | Parsers.EOF, len)
     b = buf[pos += 1]
 
     hour = 0
     for _ in 1:2
         b -= 0x30
-        b > 0x09 && (return DateTime(year, month, day), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(year, month, day), code | Parsers.INVALID, pos)
         hour = Int(b) + 10 * hour
         b = buf[pos += 1]
     end
-    hour > 24 && (return DateTime(year, month, day), code | Parsers.INVALID, pos)
-    b != UInt8(':') && (return DateTime(year, month, day, hour), code | Parsers.INVALID, pos)
+    hour > 24 && (return _unsafe_datetime(year, month, day), code | Parsers.INVALID, pos)
+    b != UInt8(':') && (return _unsafe_datetime(year, month, day, hour), code | Parsers.INVALID, pos)
     b = buf[pos += 1]
 
     minute = 0
     for _ in 1:2
         b -= 0x30
-        b > 0x09 && (return DateTime(year, month, day, hour), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(year, month, day, hour), code | Parsers.INVALID, pos)
         minute = Int(b) + 10 * minute
         b = buf[pos += 1]
     end
-    minute > 60 && (return DateTime(year, month, day, hour), code | Parsers.INVALID, pos)
-    b != UInt8(':') && (return DateTime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
+    minute > 60 && (return _unsafe_datetime(year, month, day, hour), code | Parsers.INVALID, pos)
+    b != UInt8(':') && (return _unsafe_datetime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
     b = buf[pos += 1]
 
     second = 0
     for _ in 1:2
         b -= 0x30
-        b > 0x09 && (return DateTime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
+        b > 0x09 && (return _unsafe_datetime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
         second = Int(b) + 10 * second
         pos == len && break
         b = buf[pos += 1]
     end
     pos == len && (code |= Parsers.EOF)
-    second > 60 && (return DateTime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
+    second > 60 && (return _unsafe_datetime(year, month, day, hour, minute), code | Parsers.INVALID, pos)
     if (pos == len || b == options.delim.token || b == options.cq.token)
         code |= isnothing(Dates.validargs(DateTime, year, month, day, hour, minute, second, 0)) ? Parsers.OK : Parsers.INVALID
         if Parsers.ok(code)
-            return DateTime(year, month, day, hour, minute, second), code, pos
+            return _unsafe_datetime(year, month, day, hour, minute, second), code, pos
         else
-            return DateTime(0), code, pos
+            return _unsafe_datetime(0), code, pos
         end
     end
 
@@ -98,36 +103,85 @@ Base.@propagate_inbounds function _default_tryparse_timestamp(buf, pos, len, cod
             i += 1
         end
         # TODO: rounding modes like we do for FixedPointDecimals
-        i == 0 || millisecond > 999 && (return DateTime(year, month, day, hour, minute, second), code | Parsers.INVALID, pos)
+        i == 0 || millisecond > 999 && (return _unsafe_datetime(year, month, day, hour, minute, second), code | Parsers.INVALID, pos)
         if (pos == len || (b + 0x30) == options.delim.token || b == options.cq.token)
             pos == len && (code |= Parsers.EOF)
             code |= isnothing(Dates.validargs(DateTime, year, month, day, hour, minute, second, millisecond)) ? Parsers.OK : Parsers.INVALID
             if Parsers.ok(code)
-                return DateTime(year, month, day, hour, minute, second, millisecond), code, pos
+                return _unsafe_datetime(year, month, day, hour, minute, second, millisecond), code, pos
             else
-                return DateTime(0), code, pos
+                return _unsafe_datetime(0), code, pos
             end
         end
         b += 0x30
+    elseif pos == len
+        return (_unsafe_datetime(year, month, day, hour, minute, second, millisecond), code | Parsers.OK, pos)
     end
     b == UInt8(' ') && pos < len && (b = buf[pos += 1])
-    if b == UInt8('z') || b == UInt8('Z')
-        tz = "Z"
-        pos == len ? (code |= Parsers.EOF) : (pos += 1)
-    elseif b == UInt('+') || b == UInt8('-')
-        tz, pos, b, code = Parsers.tryparsenext(Dates.DatePart{'z'}(4, false), buf, pos, len, b, code)
-    else
-        tz, pos, b, code = Parsers.tryparsenext(Dates.DatePart{'Z'}(3, false), buf, pos, len, b, code)
-    end
-    Parsers.invalid(code) && (return DateTime(year, month, day, hour, minute, second, millisecond), code , pos)
+    tz, pos, b, code = _tryparse_timezone(buf, pos, b, len, code)
+    Parsers.invalid(code) && (return _unsafe_datetime(year, month, day, hour, minute, second, millisecond), code , pos)
     if isnothing(Dates.validargs(ZonedDateTime, year, month, day, hour, minute, second, millisecond, tz))
-        ztd = TimeZones.ZonedDateTime(year, month, day, hour, minute, second, millisecond, tz)
-        return (Dates.DateTime(ztd, TimeZones.UTC), code | Parsers.OK, pos)
+        code |= Parsers.OK
+        if tz === _Z
+            # Avoiding TimeZones.ZonedDateTime to save some allocations in case the `tz`
+            # corresponds to a UTC time zone.
+            return (_unsafe_datetime(year, month, day, hour, minute, second, millisecond), code, pos)
+        else
+            dt = _unsafe_datetime(year, month, day, hour, minute, second, millisecond)
+            ztd = TimeZones.ZonedDateTime(dt, TimeZones.TimeZone(tz))
+            return (Dates.DateTime(ztd, TimeZones.UTC), code, pos)
+        end
     else
-        return (Dates.DateTime(0), code | Parsers.INVALID, pos)
+        return (Dates._unsafe_datetime(0), code | Parsers.INVALID, pos)
     end
 end
 
+# To avoid allocating a string, we reuse this constant for all UTC equivalent timezones
+# (SubString is what we get from Parsers.tryparsenext when parsing timezones)
+# This is needed until https://github.com/JuliaTime/TimeZones.jl/issues/271 is fixed
+const _Z = SubString("Z", 1:1)
+@inline function _tryparse_timezone(buf, pos, b, len, code)
+    @inbounds if b == UInt8('+') || b == UInt8('-')
+        if len - pos < 2
+        elseif buf[pos+1] == UInt8('0')
+            if buf[pos+2] == UInt8('0')
+                if len - pos < 4
+                elseif buf[pos+3] == UInt8(':')
+                    if len - pos < 5
+                    elseif buf[pos+4] == UInt8('0')
+                        if buf[pos+5] == UInt8('0')
+                            return _Z, pos+5, UInt8('0'), code
+                        end
+                    end
+                elseif buf[pos+3] == UInt8('0')
+                    if buf[pos+4] == UInt8('0')
+                        return _Z, pos+4, UInt8('0'), code
+                    end
+                end
+            end
+        end
+        return Parsers.tryparsenext(Dates.DatePart{'z'}(4, false), buf, pos, len, b, code)
+    end
+
+    @inbounds if b == UInt8('G')
+        if len - pos < 3
+        elseif buf[pos+1] == UInt8('M')
+            if buf[pos+2] == UInt8('T')
+                return (_Z, pos+3, UInt8('T'), code)
+            end
+        end
+    elseif b == UInt8('z') || b == UInt8('Z')
+        return (_Z, pos+1, b, code)
+    elseif b == UInt8('U')
+        if len - pos < 3
+        elseif buf[pos+1] == UInt8('T')
+            if buf[pos+2] == UInt8('C')
+                return (_Z, pos+3, UInt8('C'), code)
+            end
+        end
+    end
+    return Parsers.tryparsenext(Dates.DatePart{'Z'}(3, false), buf, pos, len, b, code)
+end
 
 function Parsers.typeparser(::Type{_GuessDateTime}, source::AbstractVector{UInt8}, pos, len, b, code, pl, options)
     if isnothing(options.dateformat)

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -1,0 +1,20 @@
+using Dates
+using ChunkedCSV
+using Parsers
+using Test
+
+const DT = b"1969-07-20 20:17:00"
+
+macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
+
+@testset "Parsing UTC equivalent timezones does not allocate" begin
+    for tz in (b"-00", b"+00", b"-0000", b"+0000", b"-00:00", b"+00:00", b"UTC", b"GMT")
+        dt = vcat(DT, tz)
+        @testset "$tz" begin
+            res = Parsers.xparse(ChunkedCSV._GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+            @test res.val == DateTime(1969, 7, 20, 20, 17)
+            @test Parsers.ok(res.code)
+            @test_noalloc Parsers.xparse(ChunkedCSV._GuessDateTime, dt, 1, length(dt), Parsers.OPTIONS, DateTime)
+        end
+    end
+end

--- a/test/simple_file_parsing.jl
+++ b/test/simple_file_parsing.jl
@@ -114,10 +114,12 @@ alg=:serial
                     2000-01-01 10:20:30,1969-07-20 00:00:00.000UTC
                     2000-01-01T10:20:30+0000,1969-07-20 00:00:00.000+0000
                     2000-01-01T10:20:30UTC,1969-07-19 17:00:00.000-0700
-                    2000-01-01 10:20:30+0000,1969-07-19 17:00:00.000America/Los_Angeles
+                    2000-01-01 10:20:30+00:00,1969-07-19 17:00:00.000America/Los_Angeles
                     2000-01-01 10:20:30UTC,1969-07-20 09:00:00.000+0900
                     2000-01-01 02:20:30-0800,1969-07-20 09:00:00.000 Asia/Tokyo
                     2000-01-01 10:20:30GMT,1969-07-20 00:00:00.000Z
+                    2000-01-01 10:20:30+00,1969-07-20 00:00:00.00-0000
+                    2000-01-01 10:20:30-00,1969-07-20 00:00:00.00-00:00
                     """),
                     [DateTime,DateTime],
                     testctx,
@@ -125,10 +127,10 @@ alg=:serial
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [DateTime, DateTime]
-                @test testctx.results[1].cols[1][1:12] == fill(DateTime(2000,1,1,10,20,30), 12)
-                @test testctx.results[1].cols[2][1:12] == fill(DateTime(1969,7,20,00,00,00), 12)
-                @test length(testctx.results[1].cols[1]) == 12
-                @test length(testctx.results[1].cols[2]) == 12
+                @test testctx.results[1].cols[1][1:14] == fill(DateTime(2000,1,1,10,20,30), 14)
+                @test testctx.results[1].cols[2][1:14] == fill(DateTime(1969,7,20,00,00,00), 14)
+                @test length(testctx.results[1].cols[1]) == 14
+                @test length(testctx.results[1].cols[2]) == 14
             end
 
             @testset "$alg string" begin


### PR DESCRIPTION
Fixes #4
```julia
julia> using BenchmarkTools, Parsers, Dates, ChunkedCSV

julia> bytes = b"2022-12-05T17:58:24.602+00:00";  # same datetime but now with timezone info indicating it's UTC

julia> len = length(bytes);

julia> options = Parsers.Options();

julia> @btime Parsers.xparse(ChunkedCSV._GuessDateTime, $(bytes), 1, $len, $(options), Dates.DateTime);
  106.724 ns (0 allocations: 0 bytes)
```
vs main:
```julia
julia> @btime Parsers.xparse(ChunkedCSV._GuessDateTime, $(bytes), 1, $len, $(options), Dates.DateTime);
  434.045 ns (7 allocations: 224 bytes)
```
