### PR TITLE
Non text bytes in the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,192 @@
-A simple CSV reader based on processing chunks of input.
+# ChunkedCSV.jl
+
+The main goal of this package is to offer a parser for CSV files that can be used for streaming purposes. 
+This means that it can work with data that is too large to fit into memory or in situations where we only need to process parts of the input data at a time. 
+The parser reads the data in chunks, and it can parse each chunk in parallel while simultaneously prefetching the next one to increase throughput. 
+Additionally, the parsed data is passed to a user-defined function that can consume it in any way required.
+
+Moreover, the package can automatically handle [`Parsers.jl`](https://github.com/JuliaData/Parsers.jl)-compatible types without dynamic dispatch overhead and with a low compilation overhead. 
+This is done without specializing on input schema, and the memory usage is upper bound by the user, who can control the chunk size. 
+All internally allocated buffers are reused, so if the number of values per MiB of input is roughly constant, allocations should be minimal.
+
+## Overview
+
+The package builds on [`ChunkedBase.jl`](https://github.com/JuliaData/ChunkedBase.jl), which provides a framework for parser packages, enabling them to customize three main aspects of the parsing process: how the data is parsed into a result buffer, what is the layout of the result buffer, and how the result buffer is consumed. `ChunkedBase.jl` itself handles IO, splitting chunks by newlines and distributing them among multiple workers in parallel, where they are parsed by this package and consumed.
+
+For the parsing part, this package uses the `Parsers.jl` package, and special care is taken to avoid dynamic dispatch overhead when parsing user-provided schemas without specializing on them. 
+See the `src/populate_result_buffer.jl` file for more details about how this is done.
+
+We currently only expose one result buffer type, `TaskResultBuffer`, where parsed data are stored by column and missing values are encoded in a densely packed bit matrix. 
+We also store a `RowStatus` bitset for each row, so we know if a row had any parsing errors or missing values. 
+See the `src/result_buffer.jl` file for more details.
+
+How the result buffer is consumed is up to the user, who can provide custom callback function that will be called in parallel for each chunk of data that is parsed. More on this in the "How to use" section below.
+
+## How to use
+
+The main entry point is the `parse_file` function, which accepts a path or an `IO` as the input, a `schema` which describes the types of the columns in the CSV, and a user-defined "consume context" type.
+
+Once the user provides this context, a subtype of `AbstractConsumeContext`, it will be used internally to dispatch on a custom `consume!(::AbstractConsumeContext,::ParsedPayload)` method. 
+This method will be called in parallel for each chunk of data that is parsed, and it will receive a `ParsedPayload` object that contains the parsed result buffer in the `results` field and other relevant metadata for the corresponding chunk.
+
+When no schema is provided, all columns are assumed to be `String`s and when no consume context is given, the `DebugContext` will be used. 
+This context will print a short summary for each chunk and will also print the first couple of rows with errors in each chunk.
+
+```julia
+using ChunkedCSV
+
+parse_file(
+    IOBuffer("""
+        a,b
+        1,2
+        3,4
+        5,6
+        7,8
+        9,10
+        """
+    )
+)
+# [ Info: Start row: 1, nrows: 5, Task (runnable) @0x00007fd36f5fc010 ❚
+```
+
+The user can provide a schema for the columns, and the parser will try to parse the data into the provided types. 
+There are many options to tweak the behavior of the parser, e.g. `buffersize` tells the parser to operate on 8 byte chunks of input at a time. 
+It is important that the largest row in the file you want to ingest is smaller than `buffersize` otherwise you'll get an error.
+
+```julia
+# the input is very small, we force the parser to use parallelism even if it is not needed
+parse_file(
+    IOBuffer("""
+        a,b
+        1,2
+        3,4
+        5,6
+        7,8
+        9,10
+        """
+    ), 
+    [Int, Int], 
+    buffersize=8, 
+    force=:parallel,
+)
+# [ Info: Start row: 1, nrows: 1, Task (runnable) @0x00007f6806c41f50 ❚
+# [ Info: Start row: 4, nrows: 1, Task (runnable) @0x00007f6806c41f50 ❚
+# [ Info: Start row: 2, nrows: 2, Task (runnable) @0x00007f6806f58650 ❚
+# [ Info: Start row: 5, nrows: 1, Task (runnable) @0x00007f6806e8e400 ❚
+
+# Rows 1 and 3 will fail to parse as `Int`s as they have a decimal point
+parse_file(
+    IOBuffer("""
+        a,b
+        1,2.0
+        3,4
+        5.0,6
+        7,8
+        9,10
+        """
+    ),
+    [Int, Int]
+)
+# ┌ Info: Start row: 1, nrows: 5, Task (runnable) @0x00007fd36f5fc010 ❚
+# │ Row count by status: ('✓', 3) | ('?', 2) | ('<', 0) | ('>', 0) | ('!', 2) | ('T', 0) | ('#', 0)
+# │ Example rows with errors:
+# │       (1): "1,2.0"
+# └       (3): "5.0,6"
+```
+Note that the "Row count by status" uses the `RowStatus` information we store in `TaskResultBuffer`s to show that there were 3 (`✓`) rows that were parsed successfully, 2 rows have missing values for at least one field (`?`) and 2 rows had at least one parsing error (`!`). 
+See the docstring for `TaskResultBuffer` for more information.
+
+`parse_file` also accepts a number of keyword arguments that can be used to tweak the behavior of the parser by customizing how `Parsers.jl` is used internally.
+
+```julia
+parse_file(
+    IOBuffer("""
+        # a comment
+        i;f;s
+        1_000;2,99;"A string"
+        2_000;4,99;"A string with an \\\"escaped\\\" quote"
+        3_000_000;6,99;"Usually, you'd use \\\" for the escapechar"
+        40;8,99;"But not in this example"
+        5_000_000;10,99;"No sir"
+        """
+    ),
+    [Int, Float64, String],
+    delim=';',
+    decimal=',',
+    groupmark='_',
+    escapechar='\\',
+    comment='#',
+)
+# [ Info: Start row: 1, nrows: 5, Task (runnable) @0x000000010931c010 ❚
+```
+See the docstring for more details.
+
+### Example: Custom `AbstractConsumeContext` for interactive use
+
+It could be handy to have the option to provide an anonymous function to be called on each chunk. 
+We can do that by creating a custom `AbstractConsumeContext` subtype that stores a function and dispatching on it in the `consume!` method.
+
+```julia
+using ChunkedCSV
+
+struct ClosureContext{F} <: AbstractConsumeContext
+    f::F
+end
+ChunkedCSV.consume!(ctx::ClosureContext, payload::ParsedPayload) = ctx.f(payload)
+```
+For increased ergonomics, we can also define a convenience method that calls `parse_file` with the custom context using the `do` syntax.
+
+```julia
+ChunkedCSV.parse_file(f::Function, input, schema; kwargs...) = parse_file(input, schema, ClosureContext(f); kwargs...)
+
+io = IOBuffer("""
+    a,b
+    1,2
+    3,4
+    5,6
+    7,8
+    9,10
+    """
+)
+
+parse_file(io, [Int, Int], buffersize=8) do payload
+    println("Hi there! We're at start row: $(payload.row_num), nrows: $(payload.len) in this chunk")
+end
+# Hi there! We're at start row: 1, nrows: 1 in this chunk
+# Hi there! We're at start row: 2, nrows: 2 in this chunk
+# Hi there! We're at start row: 4, nrows: 1 in this chunk
+# Hi there! We're at start row: 5, nrows: 1 in this chunk
+```
+
+## Notable differences to other CSV parsers
+
+When compared to established packages like [`CSV.jl`](https://github.com/JuliaData/CSV.jl), our package has a few notable differences:
+* We don't do any type inference for column types, so the user has to provide a schema. Otherwise, all columns will be parsed as `String`s.
+* We don't give the user back any table-like object. Instead all, results are only temporarily available in the `consume!` method of the `AbstractConsumeContext` provided. One could use this package to build a table-like object inside of the context object, but this is not provided out out of the box.
+* We pre-lex the chunks of data so that parallel parsing can be safe. `CSV.jl` does the often faster and riskier thing, where parser tasks jump directly in the file at various offsets, without knowing the record boundaries, and try to recover.
+* At the time of writing, `CSV.jl` doesn't support multithreaded parsing of *chunks*, while we do.
+* The package plays nicely with `PrefetchedDownloadStream.jl` from [`CloudStore.jl`](https://github.com/JuliaServices/CloudStore.jl), which is an IO stream that prefetches chunks of data from Amazon S3/Azure Blob Storage. This is useful for parsing large files from the cloud without having to download the whole file first, even if it is compressed.
+
+## Advanced usage
+
+### Learning the schema before creating an `AbstractConsumeContext`
+
+Sometimes, one needs to know the schema that will used to parse the file before creating a consume context. For this reason we split the `parse_file` function into two parts.
+First, we provide a `setup_parser` function which has similar interface as `parse_file` above, but doesn't require any consume context and doesn't do any parsing. 
+It will validate user input, ingest enough data chunks to reach the first valid row in the input, and then examine the first row to ensure we have a valid header and schema. 
+It will then return multiple objects:
+```julia
+(should_close, parsing_ctx, chunking_ctx, lexer) = setup_parser(input, schema; kwargs...)
+```
+- `should_close` is a `Bool` which is `true` if we opened an `IO` object we need to close later
+- `parsing_ctx` is a `ChunkedCSV.ParsingContext` which contains the header, schema, and settings needed for `Parsers.jl`
+- `chunking_ctx` is a `ChunkedBase.ChunkingContext` which holds the ingested data, newline positions and other things required by `ChunkedBase.jl` internally
+- `lexer` is a `NewlineLexers.Lexer` which is used to find newlines in the ingested chunks and which is also needed by `ChunkedBase.jl`
+
+Since the parsing context contains both the schema and the header, you can use this information to create a custom consume context.
+Once you have your `consume_ctx`, you can call `parse_file` with the state returned by `setup_parser`.
+```julia
+consume_ctx = MyCustomContext(parsing_ctx.schema, parsing_ctx.header)
+parse_file(parsing_ctx, consume_ctx, chunking_ctx, lexer)
+```
+

--- a/src/ChunkedCSV.jl
+++ b/src/ChunkedCSV.jl
@@ -1,6 +1,7 @@
 module ChunkedCSV
 
-export setup_parser, parse_file, DebugContext, AbstractConsumeContext
+export setup_parser, parse_file, ColumnIterator, DebugContext, GuessDateTime
+export AbstractConsumeContext, ParsedPayload
 export consume!, setup_tasks!, task_done!
 
 import Parsers
@@ -11,301 +12,47 @@ using SnoopPrecompile
 using ChunkedBase
 using SentinelArrays.BufferedVectors
 
+# `GuessDateTime` type is used with Parsers.jl to produce a `DateTime`
+# from various ISO8601-like formats.
 include("type_parsers/datetime_parser.jl")
+
+# Enums used to represent known types that we manually unroll on in populate_result_buffer.jl
+# Unrolling, i.e. manually dispatching on specific methods a chain of if-else statements,
+# is much easier for the compiler than unrolling on types.
 include("Enums.jl")
+
+# Utilities for validating user provided arguments and constructing
+# Parsers.Options
+include("input_arguments_handling.jl")
+
+#
+# Integration with ChunkedBase.jl
+#
+
+# How we store the parsed results
+include("result_buffer.jl")
+# How we parse the results into the result buffer
+include("populate_result_buffer.jl")
+# How we consume the results from the result buffer
+include("consume_contexts.jl")
+
+#
+# Input sniffing and setting up the parser
+#
+
+include("detect_delim.jl")
+include("init_parsing_utils.jl")
+include("init_parsing.jl")
+
+#
+# Main entrypoints
+#
+
+include("parse_file.jl")
 
 # Temporary hack to register new DateTime
 function __init__()
     Dates.CONVERSION_TRANSLATIONS[GuessDateTime] = Dates.CONVERSION_TRANSLATIONS[Dates.DateTime]
-    return nothing
-end
-
-# What we need to forward to ChunkedBase.populate_result_buffer!
-struct ParsingContext <: AbstractParsingContext
-    schema::Vector{DataType}
-    enum_schema::Vector{Enums.CSV_TYPE}
-    header::Vector{Symbol}
-    escapechar::UInt8
-    options::Parsers.Options
-end
-
-# Hold most inputs during the initialization stage where we verify them and and set things up for ChunkedBase.
-struct ParserSettings
-    header::Union{Nothing,Vector{Symbol}}
-    header_at::Int
-    data_at::Int
-    validate_type_map::Bool
-    default_colname_prefix::String
-    no_quoted_newlines::Bool
-    newlinechar::Union{Nothing,UInt8}
-    deduplicate_names::Bool
-    function ParserSettings(header::Vector{Symbol}, data_at, validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
-        new(header,  0,           Int(data_at), validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
-    end
-
-    function ParserSettings(header::Integer,        data_at, validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
-        new(nothing, Int(header), Int(data_at), validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
-    end
-end
-
-_is_supported_type(::Type{T}) where {T} = Parsers.supportedtype(T)
-_is_supported_type(::Type{Nothing}) = true
-_is_supported_type(::Type{GuessDateTime}) = true
-function _is_supported_type(::Type{FixedDecimal{T,f}}) where {T,f}
-    # https://github.com/JuliaMath/FixedPointDecimals.jl/blob/1328b9a372d2285765a7255f154f09ffdd692508/src/FixedPointDecimals.jl#L83-L91
-    n = FixedPointDecimals.max_exp10(T)
-    return f >= 0 && (n < 0 || f <= n)
-end
-
-# Separate out the types that are not pre-compiled by the parser by default
-# and return them as a single Tuple of unique types which can be passed to
-# _parse_rows_forloop! to trigger recompilation.
-function _custom_types(schema::Vector{DataType})
-    # We sort the unique types to always produce the same Tuple for the same
-    # schema. But maybe the default ordering from the IdDict is good enough?
-    custom_types = sort!(collect(keys(
-            IdDict{Type,Nothing}(
-                T => nothing for T in schema if isnothing(get(Enums._MAPPING, T, nothing))
-            ))),
-        by=objectid
-    )
-    return Tuple{custom_types...}
-end
-
-include("result_buffer.jl")
-include("detect.jl")
-include("init_parsing_utils.jl")
-include("init_parsing.jl")
-include("row_parsing.jl")
-include("consume_contexts.jl")
-
-function _create_options(;
-    delim::Union{UInt8,Char,String,Nothing}=',',
-    openquotechar::Union{UInt8,Char}='"',
-    closequotechar::Union{UInt8,Char}='"',
-    escapechar::Union{UInt8,Char}='"',
-    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
-    groupmark::Union{Char,UInt8,Nothing}=nothing,
-    stripwhitespace::Bool=false,
-    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
-    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
-    dateformat::Union{String, Dates.DateFormat, Nothing, AbstractDict}=nothing,
-    ignorerepeated::Bool=false,
-    quoted::Bool=true,
-    decimal::Union{Char,UInt8}='.',
-    ignoreemptyrows::Bool=true,
-    rounding::Union{Nothing,RoundingMode}=RoundNearest,
-)
-    return Parsers.Options(
-        sentinel=sentinel,
-        wh1=delim ==  ' ' ? '\v' : ' ',
-        wh2=delim == '\t' ? '\v' : '\t',
-        openquotechar=UInt8(openquotechar),
-        closequotechar=UInt8(closequotechar),
-        escapechar=UInt8(escapechar),
-        delim=delim,
-        quoted=quoted,
-        stripwhitespace=stripwhitespace,
-        trues=truestrings,
-        falses=falsestrings,
-        groupmark=groupmark,
-        dateformat=dateformat,
-        ignorerepeated=ignorerepeated,
-        decimal=UInt8(decimal),
-        ignoreemptylines=ignoreemptyrows,
-        rounding=rounding,
-    )
-end
-
-_validate(header::Vector, schema::Vector, validate_type_map) = length(header) == length(schema) || throw(ArgumentError("Provided header and schema lengths don't match. Header has $(length(header)) columns, schema has $(length(schema))."))
-_validate(header::Vector, schema::Dict{Symbol}, validate_type_map) = !validate_type_map || issubset(keys(schema), header) || throw(ArgumentError("Provided header and schema names don't match. In schema, not in header: $(collect(setdiff(keys(schema), header))). In header, not in schema: $(setdiff(header, keys(schema)))"))
-function _validate(header::Vector, schema::Dict{Int}, validate_type_map)
-    validate_type_map || return
-    len = length(header)
-    (lo, hi) = extrema(keys(schema))
-    (lo < 1 || hi > len) && throw(ArgumentError("Provided schema indices are incompatible with header of length $(len). Offending indices from schema $(collect(setdiff(keys(schema), 1:len))))."))
-end
-_validate(header, schema, validate_type_map) = true
-
-_nbytes(::UInt8) = 1
-_nbytes(x::Union{String,Char}) = ncodeunits(x)
-
-function validate_parser_args(;openquotechar, closequotechar, delim, escapechar, decimal, newlinechar, ignorerepeated)
-    _nbytes(openquotechar) == 1 || throw(ArgumentError("`openquotechar` must be a single-byte character"))
-    _nbytes(closequotechar) == 1 || throw(ArgumentError("`closequotechar` must be a single-byte character"))
-    if isnothing(delim)
-        ignorerepeated && throw(ArgumentError("auto-delimiter detection not supported when `ignorerepeated=true`; please provide delimiter like `delim=','`"))
-    else
-        _nbytes(delim) == 1 || throw(ArgumentError("`delim` must be a single-byte character"))
-    end
-    _nbytes(escapechar) == 1 || throw(ArgumentError("`escapechar` must be a single-byte character"))
-    _nbytes(decimal) == 1 || throw(ArgumentError("`decimal` must be a single-byte character"))
-
-    if !isnothing(newlinechar)
-        _nbytes(newlinechar) > 1 && throw(ArgumentError("`newlinechar` must be a single-byte character."))
-        ((newlinechar % UInt8) in ((openquotechar % UInt8), (closequotechar % UInt8), (escapechar % UInt8), (something(delim, 0x00) % UInt8))) &&
-            throw(ArgumentError("`newlinechar` must be different from `delim`, `openquotechar`, `closequotechar`, and `escapechar`"))
-    end
-
-    return nothing
-end
-
-function setup_parser(
-    input,
-    schema::Union{Nothing,DataType,Base.Callable,Vector{DataType},Dict{Symbol,DataType},Dict{Int,DataType}}=nothing;
-    header::Union{Vector{Symbol},Vector{String},Integer}=true,
-    skipto::Integer=0,
-    limit::Integer=0,
-    # Parsers.Options
-    delim::Union{UInt8,Char,String,Nothing}=',',
-    openquotechar::Union{UInt8,Char}='"',
-    closequotechar::Union{UInt8,Char}='"',
-    escapechar::Union{UInt8,Char}='"',
-    newlinechar::Union{UInt8,Char,Nothing}='\n',
-    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
-    groupmark::Union{Char,UInt8,Nothing}=nothing,
-    stripwhitespace::Bool=false,
-    ignorerepeated::Bool=false,
-    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
-    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
-    dateformat::Union{String, Dates.DateFormat, Nothing, AbstractDict}=nothing,
-    quoted::Bool=true,
-    decimal::Union{Char,UInt8}='.',
-    ignoreemptyrows::Bool=true,
-    rounding::Union{Nothing,RoundingMode}=RoundNearest,
-    #
-    validate_type_map::Bool=true,
-    comment::Union{Nothing,AbstractString,Char,UInt8}=nothing,
-    nworkers::Integer=max(1, Threads.nthreads() - 1),
-    # In bytes. This absolutely has to be larger than any single row.
-    # Much safer if any two consecutive rows are smaller than this threshold.
-    buffersize::Integer=(nworkers * 1024 * 1024),
-    default_colname_prefix::String="COL_",
-    use_mmap::Bool=false,
-    no_quoted_newlines::Bool=false,
-    deduplicate_names::Bool=true,
-)
-    0 <= skipto <= typemax(Int) || throw(ArgumentError("`skipto` argument must be positive and smaller than 9_223_372_036_854_775_808."))
-    (header isa Integer && !(0 <= header <= typemax(Int))) && throw(ArgumentError("`header` row number must be positive and smaller than 9_223_372_036_854_775_808."))
-    (header isa Vector{String}) && (header = map(Symbol, header))
-    if skipto == 0 && header isa Integer
-        skipto = header + 1
-    end
-    (header isa Integer && skipto <= header) && throw(ArgumentError("non-zero `skipto` argument ($skipto) must come after `header` row ($header)"))
-
-    validate_parser_args(;openquotechar, closequotechar, delim, escapechar, decimal, newlinechar, ignorerepeated)
-
-    _validate(header, schema, validate_type_map)
-
-    settings = ParserSettings(
-        header, Int(skipto), validate_type_map, default_colname_prefix,
-        no_quoted_newlines, isnothing(newlinechar) ? newlinechar : UInt8(newlinechar),
-        deduplicate_names,
-    )
-
-    chunking_ctx = ChunkingContext(buffersize, nworkers, limit, comment)
-    should_close, io = ChunkedBase._input_to_io(input, use_mmap)
-    try
-        (lexer, lines_skipped_total) = initial_read_and_lex_and_skip!(io, chunking_ctx, settings, escapechar, openquotechar, closequotechar, ignoreemptyrows)
-        # At this point we have skipped `header` rows and subsequent commented rows.
-        # The next row should contain the header and should contain clean enough data to infer
-        # the delimiter.
-        if delim === nothing
-            eols = chunking_ctx.newline_positions
-            delim = _detect_delim(chunking_ctx.bytes, first(eols)+1, last(eols), openquotechar, closequotechar, escapechar, settings.header_at > 0)
-        end
-        options = _create_options(;
-            delim, openquotechar, closequotechar, escapechar, sentinel, groupmark, stripwhitespace,
-            truestrings, falsestrings, dateformat, ignorerepeated, quoted,
-            decimal, ignoreemptyrows, rounding,
-        )
-
-        parsing_ctx = ParsingContext(DataType[], Enums.CSV_TYPE[], Symbol[], escapechar, options)
-        process_header_and_schema_and_finish_row_skip!(parsing_ctx, chunking_ctx, lexer, schema, settings, lines_skipped_total)
-        deduplicate_names && (parsing_ctx.header .= makeunique(parsing_ctx.header))
-        return should_close, parsing_ctx, chunking_ctx, lexer
-    catch
-        should_close && close(io)
-        rethrow()
-    end
-end
-
-function parse_file(
-    input,
-    schema::Union{Nothing,DataType,Base.Callable,Vector{DataType},Dict{Symbol,DataType},Dict{Int,DataType}}=nothing,
-    consume_ctx::AbstractConsumeContext=DebugContext();
-    header::Union{Vector{Symbol},Vector{String},Integer}=true,
-    skipto::Integer=0,
-    limit::Integer=0,
-    # Parsers.Options
-    delim::Union{UInt8,Char,String,Nothing}=',',
-    openquotechar::Union{UInt8,Char}='"',
-    closequotechar::Union{UInt8,Char}='"',
-    escapechar::Union{UInt8,Char}='"',
-    newlinechar::Union{UInt8,Char,Nothing}='\n',
-    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
-    groupmark::Union{Char,UInt8,Nothing}=nothing,
-    stripwhitespace::Bool=false,
-    ignorerepeated::Bool=false,
-    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
-    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
-    dateformat::Union{String, Dates.DateFormat, Nothing, AbstractDict}=nothing,
-    quoted::Bool=true,
-    decimal::Union{Char,UInt8}='.',
-    ignoreemptyrows::Bool=true,
-    rounding::Union{Nothing,RoundingMode}=RoundNearest,
-    #
-    comment::Union{Nothing,String,Char,UInt8}=nothing,
-    validate_type_map::Bool=true,
-    nworkers::Integer=max(1, Threads.nthreads() - 1),
-    # In bytes. This absolutely has to be larger than any single row.
-    # Much safer if any two consecutive rows are smaller than this threshold.
-    buffersize::Integer=(nworkers * 1024 * 1024),
-    _force::Symbol=:default,
-    default_colname_prefix::String="COL_",
-    use_mmap::Bool=false,
-    no_quoted_newlines::Bool=false,
-    deduplicate_names::Bool=false,
-)
-    _force in (:default, :serial, :parallel) || throw(ArgumentError("`_force` argument must be one of (:default, :serial, :parallel)."))
-    (should_close, parsing_ctx, chunking_ctx, lexer) = setup_parser(
-        input, schema;
-        header, skipto, delim, openquotechar, closequotechar, limit, escapechar, newlinechar,
-        sentinel, groupmark, stripwhitespace, truestrings, falsestrings, dateformat, comment,
-        rounding, validate_type_map, default_colname_prefix, buffersize, nworkers,
-        use_mmap, no_quoted_newlines, ignorerepeated, quoted, decimal, ignoreemptyrows,
-        deduplicate_names,
-    )
-    try
-        parse_file(lexer, parsing_ctx, consume_ctx, chunking_ctx, _force)
-    finally
-        should_close && close(lexer.io)
-    end
-    return nothing
-end
-
-function parse_file(
-    lexer::Lexer,
-    parsing_ctx::ParsingContext,
-    consume_ctx::AbstractConsumeContext,
-    chunking_ctx::ChunkingContext,
-    _force::Symbol=:default,
-)
-    _force in (:default, :serial, :parallel) || throw(ArgumentError("`_force` argument must be one of (:default, :serial, :parallel)."))
-    schema = parsing_ctx.schema
-    CT = _custom_types(schema)
-
-    nrows = length(chunking_ctx.newline_positions) - 1
-    if ChunkedBase.should_use_parallel(chunking_ctx, _force)
-        ntasks = tasks_per_chunk(chunking_ctx)
-        nbuffers = total_result_buffers_count(chunking_ctx)
-        result_buffers = _make_result_buffers(nbuffers, schema, cld(nrows, ntasks))
-        parse_file_parallel(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buffers, CT)
-    else
-        result_buf = TaskResultBuffer(0, parsing_ctx.schema, nrows)
-        parse_file_serial(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buf, CT)
-    end
-
     return nothing
 end
 

--- a/src/Enums.jl
+++ b/src/Enums.jl
@@ -4,9 +4,13 @@ module Enums
     using FixedPointDecimals
     using ..ChunkedCSV: GuessDateTime
 
+    # Enums used to represent _known_ input-types that we manually unroll in populate_result_buffer.jl
+	# Unrolling on enums is easier for the compiler than unrolling on types.
+	# For _unknown_ input-types, we use a generated function to unroll on the types in the schema,
+	# see `parsecustom!` for how this is used.
     @enum CSV_TYPE::UInt8 begin
         UNKNOWN
-        SKIP
+        SKIP # This represents a column that was skipped by the user
         INT
         BOOL
         FLOAT64
@@ -31,6 +35,7 @@ module Enums
         Parsers.PosLen31 => STRING,
     )
 
+    # Check we don't miss any types in the mapping
     @assert isempty(symdiff(Base.instances(CSV_TYPE), unique(values(_MAPPING)))) symdiff(Base.instances(CSV_TYPE), unique(values(_MAPPING)))
 
     to_enum(@nospecialize(T)) = @inbounds get(_MAPPING, T, UNKNOWN)::CSV_TYPE

--- a/src/detect_delim.jl
+++ b/src/detect_delim.jl
@@ -1,4 +1,4 @@
-# Common delimiters used in textual, delimited files
+# Common delimiters used in textual delimited files
 const CANDIDATE_DELIMS = (UInt8(','), UInt8(';'), UInt8('|'), UInt8(':'), UInt8('\t'), UInt8(' '))
 const DEFAULT_LINES_TO_DETECT_DELIM = 11
 @assert !(0xFF in CANDIDATE_DELIMS)

--- a/src/init_parsing.jl
+++ b/src/init_parsing.jl
@@ -1,19 +1,22 @@
 struct HeaderParsingError <: Exception
     msg::String
 end
-Base.showerror(io::IO, e::HeaderParsingError) = print(io, e.msg)
+Base.showerror(io::IO, e::HeaderParsingError) = print(io, "HeaderParsingError: ", e.msg)
 
-function initial_read_and_lex_and_skip!(io, chunking_ctx, settings, escapechar, openquotechar, closequotechar, ignoreemptyrows)
+# We might need to skip some rows to get to the header and then skip again to get to the data
+# This function does the *first* skip and initializes the ChunkingContext and Lexer
+# If the newline is not provided, we'll need to detect it first
+function initial_read_and_lex_and_skip!(io, chunking_ctx, input_args, escapechar, openquotechar, closequotechar, ignoreemptyrows)
     # First ingestion of raw bytes from io
     bytes_read_in = ChunkedBase.initial_read!(io, chunking_ctx)
 
     # We need to detect the newline first to construct the Lexer
-    newline = settings.newlinechar
+    newline = input_args.newlinechar
     if isnothing(newline)
         newline = ChunkedBase._detect_newline(chunking_ctx.bytes, 1, bytes_read_in)
     end
 
-    lexer = settings.no_quoted_newlines ?
+    lexer = input_args.no_quoted_newlines ?
         Lexer(io, nothing, newline) :
         Lexer(io, escapechar, openquotechar, closequotechar, newline)
 
@@ -21,129 +24,167 @@ function initial_read_and_lex_and_skip!(io, chunking_ctx, settings, escapechar, 
     ChunkedBase.initial_lex!(lexer, chunking_ctx, bytes_read_in)
 
     # First skip over commented lines, then jump to header / data row
-    should_parse_header = settings.header_at > 0
-    pre_header_skiprows = max(0, (should_parse_header ? settings.header_at : settings.data_at) - 1)
+    should_parse_header = input_args.header_at > 0
+    pre_header_skiprows = max(0, (should_parse_header ? input_args.header_at : input_args.data_at) - 1)
     lines_skipped_total = ChunkedBase.skip_rows_init!(lexer, chunking_ctx, pre_header_skiprows, ignoreemptyrows)
 
     return lexer, lines_skipped_total
 end
 
+# This function does the *second* skip and initializes the parsing context
+# (see the function above for the first skip).
+# We cannot construct the parsing context without knowing the schema and the header,
+# we'll take inputs the user provided for schema and header and we'll reconcile it with the
+# header row or at least with the number of columns in the file. We don't do type inference yet,
+# so any unknown types will be filled with String if the user didn't give us a vector of types already.
 function process_header_and_schema_and_finish_row_skip!(
     parsing_ctx::ParsingContext,
     chunking_ctx::ChunkingContext,
     lexer::Lexer,
     schema_input,
-    settings::ParserSettings,
+    input_args::InputArguments,
     lines_skipped_total::Int
 )
     input_is_empty = length(chunking_ctx.newline_positions) == 1
     options = parsing_ctx.options
     ignorerepeated = options.ignorerepeated
 
-    header_provided = !isnothing(settings.header)
+    header_provided = !isnothing(input_args.header)
     schema_provided = schema_input isa Vector{DataType}
-    should_parse_header = settings.header_at > 0
+    should_parse_header = input_args.header_at > 0
     schema = parsing_ctx.schema
     schema_provided && validate_schema(schema_input)
+    newlines = chunking_ctx.newline_positions
 
-    @inbounds if schema_provided & header_provided
-        append!(parsing_ctx.header, settings.header)
+    if schema_provided & header_provided
+        # The user actually provided a schema and a header, so we just give to the parsing context
+        append!(parsing_ctx.header, input_args.header)
         append!(schema, schema_input)
     elseif !schema_provided & header_provided
-        append!(parsing_ctx.header, settings.header)
-        _fill_schema!(schema, parsing_ctx.header, schema_input, settings)
+        # The user provided a header but no schema, and since we don't infer types, we just fill
+        # the schema with String
+        append!(parsing_ctx.header, input_args.header)
+        _fill_schema!(schema, parsing_ctx.header, schema_input, input_args)
     elseif schema_provided & !header_provided
+        # The user provided a schema but no header, so we need to infer the header from the first row
         append!(schema, schema_input)
         if !should_parse_header || input_is_empty
+            # The file doesn't have a header, so we just fill the header with default names
             for i in 1:length(schema_input)
-                push!(parsing_ctx.header, Symbol(string(settings.default_colname_prefix, i)))
+                push!(parsing_ctx.header, Symbol(string(input_args.default_colname_prefix, i)))
             end
-        else # should_parse_header
-            s = chunking_ctx.newline_positions[1]
-            e = chunking_ctx.newline_positions[2]
-            v = @view chunking_ctx.bytes[s+1:e-1]
+        else
+            # The file has a header, so we parse it and fill the header with the parsed names
+            header_row_start = newlines[1]
+            header_row_end   = newlines[2]
+            row_bytes = @view chunking_ctx.bytes[header_row_start+1:header_row_end-1]
+
+            len = length(row_bytes)
             pos = 1
-            ignorerepeated && (pos = Parsers.checkdelim!(v, pos, length(v), options))
+            # `ignorerepeated` is used to implement fixed width column parsing. We need to skip over the initial
+            # delimiters to avoid getting an empty first value.
+            ignorerepeated && (pos = Parsers.checkdelim!(row_bytes, pos, len, options))
             code = Parsers.OK
-            for i in 1:length(schema_input)
-                Parsers.eof(code) && throw(HeaderParsingError("Not enough columns in header, found $(i-1), provided schema implied $(length(schema_input)) at $(lines_skipped_total+1):$(pos) (row:pos)."))
-                res = Parsers.xparse(String, v, pos, length(v), options, Parsers.PosLen31)
+            ncols = length(schema_input)
+            for i in 1:ncols
+                Parsers.eof(code) && throw(HeaderParsingError("Not enough columns in header, found $(i-1), provided schema implied $ncols at $(lines_skipped_total+1):$pos (row:pos)."))
+                res = Parsers.xparse(String, row_bytes, pos, len, options, Parsers.PosLen31)
+
                 (val, tlen, code) = res.val, res.tlen, res.code
+
                 if Parsers.sentinel(code)
-                    push!(parsing_ctx.header, Symbol(string(settings.default_colname_prefix, i)))
+                    push!(parsing_ctx.header, Symbol(string(input_args.default_colname_prefix, i)))
                 elseif !Parsers.ok(code)
                     throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$(pos) (row:pos)."))
                 else
-                    push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(v, val, options.e))))
+                    push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(row_bytes, val, options.e))))
                 end
                 pos += tlen
             end
             if !(Parsers.eof(code) || Parsers.newline(code))
                 # There are too many columns; calculate how many extra so we can inform the user.
-                ncols = length(parsing_ctx.header)
+                ncols_actual = length(parsing_ctx.header)
                 while !Parsers.eof(code)
-                    res = Parsers.xparse(String, v, pos, length(v), options, Parsers.PosLen31)
+                    res = Parsers.xparse(String, row_bytes, pos, len, options, Parsers.PosLen31)
                     (tlen, code) = res.tlen, res.code
                     pos += tlen
-                    ncols += 1
+                    ncols_actual += 1
                 end
-                throw(HeaderParsingError("Error parsing header, there are more columns ($ncols) than provided types in schema ($(length(schema_input))) at $(lines_skipped_total+1):$(pos) (row:pos)."))
+                throw(HeaderParsingError("Error parsing header, there are more columns ($ncols_actual) than provided types in schema ($ncols) at $(lines_skipped_total+1):$(pos) (row:pos)."))
             end
         end
     elseif !should_parse_header
+        # The user didn't provide a schema nor the header and the file *doesn't* have a header,
+        # so we need to infer the number of columns from the first row and fill the schema with String.
         input_is_empty && return nothing
         # infer the number of columns from the first data row
-        s = chunking_ctx.newline_positions[1]
-        e = chunking_ctx.newline_positions[2]
-        v = @view chunking_ctx.bytes[s+1:e-1]
+        header_row_start = newlines[1]
+        header_row_end   = newlines[2]
+        row_bytes = @view chunking_ctx.bytes[header_row_start+1:header_row_end-1]
+
+        len = length(row_bytes)
         pos = 1
-        ignorerepeated && (pos = Parsers.checkdelim!(v, pos, length(v), options))
+        # `ignorerepeated` is used to implement fixed width column parsing. We need to skip over the initial
+        # delimiters to avoid getting an empty first value.
+        ignorerepeated && (pos = Parsers.checkdelim!(row_bytes, pos, len, options))
         code = Parsers.OK
         i = 1
         while !(Parsers.eof(code) || Parsers.newline(code))
-            res = Parsers.xparse(String, v, pos, length(v), options, Parsers.PosLen31)
+            res = Parsers.xparse(String, row_bytes, pos, len, options, Parsers.PosLen31)
             (tlen, code) = res.tlen, res.code
+
             !(Parsers.ok(code) || Parsers.sentinel(code)) && (throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$(pos) (row:pos).")))
+
+            push!(parsing_ctx.header, Symbol(string(input_args.default_colname_prefix, i)))
             pos += tlen
-            push!(parsing_ctx.header, Symbol(string(settings.default_colname_prefix, i)))
             i += 1
         end
-        _fill_schema!(schema, parsing_ctx.header, schema_input, settings)
+        _fill_schema!(schema, parsing_ctx.header, schema_input, input_args)
     else
+        # The user didn't provide a schema nor the header and the file *does* have a header,
+        # so we need to infer the header from the first row and fill the schema with String.
         input_is_empty && return nothing
         # infer the number of columns from the header row
-        s = chunking_ctx.newline_positions[1]
-        e = chunking_ctx.newline_positions[2]
-        v = view(chunking_ctx.bytes, s+1:e-1)
+        header_row_start = newlines[1]
+        header_row_end   = newlines[2]
+        row_bytes = @view chunking_ctx.bytes[header_row_start+1:header_row_end-1]
+
+        len = length(row_bytes)
         pos = 1
-        ignorerepeated && (pos = Parsers.checkdelim!(v, pos, length(v), options))
+        # `ignorerepeated` is used to implement fixed width column parsing. We need to skip over the initial
+        # delimiters to avoid getting an empty first value.
+        ignorerepeated && (pos = Parsers.checkdelim!(row_bytes, pos, len, options))
         code = Parsers.OK
         i = 1
         while !((Parsers.eof(code) && !Parsers.delimited(code)) || Parsers.newline(code))
-            res = Parsers.xparse(String, v, pos, length(v), options, Parsers.PosLen31)
+            res = Parsers.xparse(String, row_bytes, pos, len, options, Parsers.PosLen31)
+
             (val, tlen, code) = res.val, res.tlen, res.code
+
             if Parsers.sentinel(code)
-                push!(parsing_ctx.header, Symbol(string(settings.default_colname_prefix, i)))
+                push!(parsing_ctx.header, Symbol(string(input_args.default_colname_prefix, i)))
             elseif !Parsers.ok(code)
-                throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$(pos) (row:pos)."))
+                throw(HeaderParsingError("Error parsing header for column $i at $(lines_skipped_total+1):$pos (row:pos)."))
             else
-                push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(v, val, options.e))))
+                push!(parsing_ctx.header, Symbol(strip(Parsers.getstring(row_bytes, val, options.e))))
             end
             pos += tlen
             i += 1
         end
-        _fill_schema!(schema, parsing_ctx.header, schema_input, settings)
+        _fill_schema!(schema, parsing_ctx.header, schema_input, input_args)
     end
     !schema_provided && validate_schema(schema)
 
-    should_parse_header && !input_is_empty && shiftleft!(chunking_ctx.newline_positions, 1) # remove the header row from eols
+    # remove the header row from newlines so we don't have to worry about it in the
+    # main parsing loop
+    should_parse_header && !input_is_empty && shiftleft!(newlines, 1)
     # Refill the buffer if it contained a single line and we consumed it to get the header
-    if should_parse_header && length(chunking_ctx.newline_positions) == 1 && !eof(lexer.io)
+    if should_parse_header && length(newlines) == 1 && !eof(lexer.io)
        ChunkedBase.read_and_lex!(lexer, chunking_ctx)
     end
 
     # Skip over commented lines, then jump to data row if needed
-    post_header_skiprows = should_parse_header ? settings.data_at - settings.header_at - 1 : 0
+    post_header_skiprows = should_parse_header ? input_args.data_at - input_args.header_at - 1 : 0
     ChunkedBase.skip_rows_init!(lexer, chunking_ctx, post_header_skiprows)
 
     # This is where we create the enum'd counterpart of parsing_ctx.schema, parsing_ctx.enum_schema

--- a/src/input_arguments_handling.jl
+++ b/src/input_arguments_handling.jl
@@ -1,0 +1,127 @@
+# These are the user-provided arguments to `parse_file` or `setup_parser`, that we need to
+# use for the bootstrapping phase, when we skip any unwanted leading rows and sniff the beginning of
+# the file to determine/validate the newline, header, schema, etc.
+# We'll use them to construct the `Lexer`, `ParsingContext` and `ChunkingContext`,
+# after we sniff the beginning the file to determine the newline,
+# header, etc.
+struct InputArguments
+    header::Union{Nothing,Vector{Symbol}}
+    header_at::Int
+    data_at::Int
+    validate_type_map::Bool
+    default_colname_prefix::String
+    no_quoted_newlines::Bool
+    newlinechar::Union{Nothing,UInt8}
+    deduplicate_names::Bool
+    function InputArguments(header::Vector{Symbol}, data_at, validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
+        new(header,  0,           Int(data_at), validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
+    end
+
+    function InputArguments(header::Integer,        data_at, validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
+        new(nothing, Int(header), Int(data_at), validate_type_map, default_colname_prefix, no_quoted_newlines, newlinechar, deduplicate_names)
+    end
+end
+
+# Fail early if the user is trying to parse something we don't know how to parse
+_is_supported_type(::Type{T}) where {T} = Parsers.supportedtype(T)
+_is_supported_type(::Type{Nothing}) = true # Column skipping
+_is_supported_type(::Type{GuessDateTime}) = true # Our custom DateTime parser that handles multiple subsets of ISO8601
+function _is_supported_type(::Type{FixedDecimal{T,f}}) where {T,f}
+    # This check is copied from FixedPointDecimals.jl, the library uses it as runtime check,
+    # but we want to fail early if the user is trying to parse something is not possible to construct.
+    # https://github.com/JuliaMath/FixedPointDecimals.jl/blob/1328b9a372d2285765a7255f154f09ffdd692508/src/FixedPointDecimals.jl#L83-L91
+    n = FixedPointDecimals.max_exp10(T)
+    return f >= 0 && (n < 0 || f <= n)
+end
+
+# Separate out the types that are not pre-compiled by the parser by default
+# and return them as a single Tuple of unique types which can be passed to
+# populate_result_buffer! to trigger recompilation. See `parsecustom!`
+# in src/populate_result_buffer.jl for how this is used.
+function _custom_types(schema::Vector{DataType})
+    # We sort the unique types to always produce the same Tuple for the same
+    # schema. But maybe the default ordering from the IdDict is good enough?
+    custom_types = sort!(collect(keys(
+            IdDict{Type,Nothing}(
+                T => nothing for T in schema if isnothing(get(Enums._MAPPING, T, nothing))
+            ))),
+        by=objectid
+    )
+    return Tuple{custom_types...}
+end
+
+# Parsers.Options constructor with our defaults.
+# Used in `setup_parser`.
+function _create_options(;
+    delim::Union{UInt8,Char,String,Nothing}=',',
+    openquotechar::Union{UInt8,Char}='"',
+    closequotechar::Union{UInt8,Char}='"',
+    escapechar::Union{UInt8,Char}='"',
+    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
+    groupmark::Union{Char,UInt8,Nothing}=nothing,
+    stripwhitespace::Bool=false,
+    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
+    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
+    dateformat::Union{String, Dates.DateFormat, Nothing, AbstractDict}=nothing,
+    ignorerepeated::Bool=false,
+    quoted::Bool=true,
+    decimal::Union{Char,UInt8}='.',
+    ignoreemptyrows::Bool=true,
+    rounding::Union{Nothing,RoundingMode}=RoundNearest,
+)
+    return Parsers.Options(
+        sentinel=sentinel,
+        wh1=delim ==  ' ' ? '\v' : ' ',
+        wh2=delim == '\t' ? '\v' : '\t',
+        openquotechar=UInt8(openquotechar),
+        closequotechar=UInt8(closequotechar),
+        escapechar=UInt8(escapechar),
+        delim=delim,
+        quoted=quoted,
+        stripwhitespace=stripwhitespace,
+        trues=truestrings,
+        falses=falsestrings,
+        groupmark=groupmark,
+        dateformat=dateformat,
+        ignorerepeated=ignorerepeated,
+        decimal=UInt8(decimal),
+        ignoreemptylines=ignoreemptyrows,
+        rounding=rounding,
+    )
+end
+
+# Check that the schema and header are compatible
+_validate(header::Vector, schema::Vector, validate_type_map) = length(header) == length(schema) || throw(ArgumentError("Provided header and schema lengths don't match. Header has $(length(header)) columns, schema has $(length(schema))."))
+_validate(header::Vector, schema::Dict{Symbol}, validate_type_map) = !validate_type_map || issubset(keys(schema), header) || throw(ArgumentError("Provided header and schema names don't match. In schema, not in header: $(collect(setdiff(keys(schema), header))). In header, not in schema: $(setdiff(header, keys(schema)))"))
+function _validate(header::Vector, schema::Dict{Int}, validate_type_map)
+    validate_type_map || return
+    len = length(header)
+    (lo, hi) = extrema(keys(schema))
+    (lo < 1 || hi > len) && throw(ArgumentError("Provided schema indices are incompatible with header of length $(len). Offending indices from schema $(collect(setdiff(keys(schema), 1:len))))."))
+end
+_validate(header, schema, validate_type_map) = true
+
+_nbytes(::UInt8) = 1
+_nbytes(x::Union{String,Char}) = ncodeunits(x)
+
+# We're a bit stricter than Parsers.jl here, because the Lexer doesn't support
+# multi-byte characters.
+function validate_parser_args(;openquotechar, closequotechar, delim, escapechar, decimal, newlinechar, ignorerepeated)
+    _nbytes(openquotechar) == 1 || throw(ArgumentError("`openquotechar` must be a single-byte character"))
+    _nbytes(closequotechar) == 1 || throw(ArgumentError("`closequotechar` must be a single-byte character"))
+    if isnothing(delim)
+        ignorerepeated && throw(ArgumentError("auto-delimiter detection not supported when `ignorerepeated=true`; please provide delimiter like `delim=','`"))
+    else
+        _nbytes(delim) == 1 || throw(ArgumentError("`delim` must be a single-byte character"))
+    end
+    _nbytes(escapechar) == 1 || throw(ArgumentError("`escapechar` must be a single-byte character"))
+    _nbytes(decimal) == 1 || throw(ArgumentError("`decimal` must be a single-byte character"))
+
+    if !isnothing(newlinechar)
+        _nbytes(newlinechar) > 1 && throw(ArgumentError("`newlinechar` must be a single-byte character."))
+        ((newlinechar % UInt8) in ((openquotechar % UInt8), (closequotechar % UInt8), (escapechar % UInt8), (something(delim, 0x00) % UInt8))) &&
+            throw(ArgumentError("`newlinechar` must be different from `delim`, `openquotechar`, `closequotechar`, and `escapechar`"))
+    end
+
+    return nothing
+end

--- a/src/parse_file.jl
+++ b/src/parse_file.jl
@@ -1,0 +1,269 @@
+const _API_DOCS_SHARED = """
+## Arguments
+- `input`: The input source to parse. Can be a `String` file path or an `IO` object.
+- `schema`: An optional schema for the CSV file, if omitted, all columns would be parsed as `String`s. It can be
+    - a single `DataType` in which case it will be used for all columns in the file,
+    - a `Vector{DataType}` in which case each element of the vector would correspond to single column,
+    - a `Dict{Symbol,DataType}` which will map a types to columns by name,
+    - a `Dict{Int,DataType}` which will map types to columns by position, or
+    - a `Base.Callable` which will be called with the column index and name and should return a `DataType`.
+    For the vector case, the length must match the number of columns in the CSV file.
+    For the dictionary case, the keys must be a subset of the column names in the CSV file (unless `validate_type_map` is set to `false`),
+    columns that are not present in the mapping will be parsed as `String`s.
+- `consume_ctx`: A user-defined `<:AbstractConsumeContext` object which will be used to dispatch on `consume!(::C, ::ParsedPayload)` to consume the parsed data om each of `nworkers` tasks in parallel.
+## Keyword arguments
+- `header`: How the column names should be determined.
+    They can be given explicitly as a `Vector{Symbol}` or a `Vector{String}`, which must match the number of columns in the input.
+    Alternatively a positive `Integer` can set the row number from which the header should be parsed.
+    This number is relative to the first row that wasn't empty and/or commented if you set `ignoreemptyrows` and/or `comment`.
+    A value of `0` or `false` indicates that no header is present in the CSV file.
+    You can use `skipto` to skip over headers that fail to parse for whatever reason.
+- `skipto`: The number of rows to skip before parsing the CSV file. Defaults to `0` (no skipping).
+    This number is relative to the first row that wasn't empty and/or commented if you set `ignoreemptyrows` and/or `comment`.
+- `limit`: The maximum number of rows to parse. Defaults to `0` (no limit). Used in [`ChunkedBase.ChunkingContext`](@ref).
+### Parsing-related options
+- `delim`: The delimiter character used in the CSV file. Defaults to `','`. Only single-byte characters are supported. `nothing` indicates that the delimiter should be inferred from the first chunk of data. Used in [`Parsers.Options`](@ref).
+- `openquotechar`: The character used to open quoted fields in the CSV file. Defaults to `'"'`. Only single-byte characters are supported. Used in [`Parsers.Options`](@ref).
+- `closequotechar`: The character used to close quoted fields in the CSV file. Defaults to `'"'`. Only single-byte characters are supported. Used in [`Parsers.Options`](@ref).
+- `escapechar`: The character used to escape special characters in the CSV file. Defaults to `'"'`. Only single-byte characters are supported. Used in [`Parsers.Options`](@ref).
+- `newlinechar`: The character used to represent newlines in the CSV file. Defaults to `'\\n'`. Only single-byte characters are supported. `nothing` indicates that the newline character should be inferred from the first chunk of data. Used in [`Parsers.Options`](@ref).
+- `sentinel`: A sentinel value used to indicate missing values in the CSV file. Multiple sentinels might be provided as a `Vector{String}`. Used in [`Parsers.Options`](@ref).
+    Defaults to `missing`, meaning that empty fields (two consecutive `delim`s) will be treated as missing values. Used in [`Parsers.Options`](@ref)
+- `groupmark`: The character used to group digits in numbers in the CSV file. Defaults to `nothing` (group marks are not expected). Used in [`Parsers.Options`](@ref).
+- `stripwhitespace`: Whether to strip whitespace from fields in the CSV file. Defaults to `false`. Used in [`Parsers.Options`](@ref).
+- `ignorerepeated`: Whether to ignore repeated delimiters in the CSV file. Defaults to `false`. Used in [`Parsers.Options`](@ref).
+- `truestrings`: A vector of strings representing `true` values in the CSV file. Defaults to `["true", "True", "TRUE", "1", "t", "T"]`. Used in [`Parsers.Options`](@ref).
+- `falsestrings`: A vector of strings representing `false` values in the CSV file. Defaults to `["false", "False", "FALSE", "0", "f", "F"]`. Used in [`Parsers.Options`](@ref).
+- `dateformat`: The date format used in the CSV file. Defaults to `nothing`, in which case `Parsers.defaul_format` is used. Consider using `GuessDateTime` as a schema type instead. Used in [`Parsers.Options`](@ref).
+- `quoted`: Whether fields in the CSV file are quoted. Defaults to `true`. Used in [`Parsers.Options`](@ref).
+- `decimal`: The character used as the decimal separator in numbers in the CSV file. Defaults to `'.'`. Only single-byte characters are supported. Used in [`Parsers.Options`](@ref).
+- `ignoreemptyrows`: Whether to ignore empty rows in the CSV file. Defaults to `true`. Used in [`Parsers.Options`](@ref).
+- `rounding`: The rounding mode used for `FixedDecimal` and `DateTime` values in the CSV file. Defaults to `RoundNearest`. Used in [`Parsers.Options`](@ref).
+- `validate_type_map`: Whether to validate the keys in provided schema dictionaries against the column names / the number of columns in the CSV file. Defaults to `true`.
+- `comment`: The string or byte prefix used to indicate comments in the CSV file. Defaults to `nothing` which means no comment skipping will be performed. Used in [`ChunkedBase.ChunkingContext`](@ref).
+### Chunking and parallelism
+- `nworkers`: The number of worker threads to use for parsing the CSV file. Defaults to `max(1, Threads.nthreads() - 1)`. Used in [`ChunkedBase.ChunkingContext`](@ref).
+- `buffersize`: The size of the buffer used for parsing the CSV file, in bytes. Defaults to `nworkers * 1024 * 1024`. Must be larger than any single row in input and smaller than 2GiB.
+    If the input is larger than `buffersize` and if we're using `nworkers` > 1, a secondary buffer will be allocated internally to facilitate double-buffering. Used in [`ChunkedBase.ChunkingContext`](@ref).
+### Misc
+- `default_colname_prefix`: The default prefix to use for generated column names in the CSV file, used when some of the names are missing or when the file is missing the header altogether. Defaults to `"COL_"`.
+- `use_mmap`: Whether to use memory-mapped I/O for parsing the CSV file when the `input` is a `String` path. Defaults to `false`.
+- `no_quoted_newlines`: Assert that all newline characters in the file are record delimiters and never part of string field data. This allows the lexer to find newlines more efficiently, but will lead to parsing errors if there are quoted newlines in the file. Defaults to `false`.
+- `deduplicate_names`: Whether to deduplicate column names in the CSV file by enumerating the colliding names with a `_1`, `_2`... suffixes. Defaults to `true`. Columns names are not significant during parsing, but they might be significant for the user when consuming the parsed data.
+- `force`: Force parallel or serial parsing regardless of input size of `nworkers`. One of `:default`, `:serial` or `:parallel`. Defaults to `:default`, which won't parallelize small files or use the parallel code-path with `nworkers == 1`. Useful for debugging.
+"""
+
+const _SEE_ALSO = """
+## See also
+- [`TaskResultBuffer`](@ref), [`ParsedPayload`](@ref), [`AbstractConsumeContext`](@ref), [`consume!`](@ref)
+- `ChunkedBase.jl` for more information about the `ChunkedBase` API.
+"""
+
+
+"""
+    setup_parser(input, schema=nothing; kwargs...) -> (Bool, ParsingContext, ChunkingContext, Lexer)
+
+For when you need to know the header and / or the schema which will be used to parse the file before creating your `consume_ctx`.
+
+`setup_parser` will validate user input, ingest enough data chunks to reach the first valid row in the input, and then examine the first row to ensure we have a valid header and schema.
+You can then inspect the returned `ParsingContext` to see what the header and schema will be, and then call `parse_file` with the other objects returned by `setup_parser`.
+
+$_API_DOCS_SHARED
+
+## Returns
+- `should_close::Bool`: `true` if we opened an `IO` object and we should close it later
+- `parsing_ctx::ChunkedCSV.ParsingContext`: Internal object, which contains the header, schema and settings needed for `Parsers.jl`
+- `chunking_ctx::ChunkedBase.ChunkingContext`: Internal object, which holds the ingested data, newline positions and other things required by `ChunkedBase.jl` internally
+- `lexer::NewlineLexers.Lexer`: Internal object, which is used to find newlines in the ingested chunks and which is also needed by `ChunkedBase.jl`
+
+$_SEE_ALSO
+- [`parse_file`](@ref)
+"""
+function setup_parser(
+    input,
+    schema::Union{Nothing,DataType,Base.Callable,Vector{DataType},Dict{Symbol,DataType},Dict{Int,DataType}}=nothing;
+    header::Union{Vector{Symbol},Vector{String},Integer}=true,
+    skipto::Integer=0,
+    limit::Integer=0,
+    # Parsers.Options
+    delim::Union{UInt8,Char,String,Nothing}=',',
+    openquotechar::Union{UInt8,Char}='"',
+    closequotechar::Union{UInt8,Char}='"',
+    escapechar::Union{UInt8,Char}='"',
+    newlinechar::Union{UInt8,Char,Nothing}='\n',
+    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
+    groupmark::Union{Char,UInt8,Nothing}=nothing,
+    stripwhitespace::Bool=false,
+    ignorerepeated::Bool=false,
+    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
+    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
+    dateformat::Union{String, Dates.DateFormat, Nothing}=nothing,
+    quoted::Bool=true,
+    decimal::Union{Char,UInt8}='.',
+    ignoreemptyrows::Bool=true,
+    rounding::Union{Nothing,RoundingMode}=RoundNearest,
+    #
+    validate_type_map::Bool=true,
+    comment::Union{Nothing,AbstractString,Char,UInt8}=nothing,
+    nworkers::Integer=max(1, Threads.nthreads() - 1),
+    # In bytes. This absolutely has to be larger than any single row.
+    # Much safer if any two consecutive rows are smaller than this threshold.
+    buffersize::Integer=(nworkers * 1024 * 1024),
+    default_colname_prefix::String="COL_",
+    use_mmap::Bool=false,
+    no_quoted_newlines::Bool=false,
+    deduplicate_names::Bool=true,
+)
+    0 <= skipto <= typemax(Int) || throw(ArgumentError("`skipto` argument must be positive and smaller than 9_223_372_036_854_775_808."))
+    (header isa Integer && !(0 <= header <= typemax(Int))) && throw(ArgumentError("`header` row number must be positive and smaller than 9_223_372_036_854_775_808."))
+    (header isa Vector{String}) && (header = map(Symbol, header))
+    if skipto == 0 && header isa Integer
+        skipto = header + 1
+    end
+    (header isa Integer && skipto <= header) && throw(ArgumentError("non-zero `skipto` argument ($skipto) must come after `header` row ($header)"))
+
+    validate_parser_args(;openquotechar, closequotechar, delim, escapechar, decimal, newlinechar, ignorerepeated)
+
+    _validate(header, schema, validate_type_map)
+
+    settings = InputArguments(
+        header, Int(skipto), validate_type_map, default_colname_prefix,
+        no_quoted_newlines, isnothing(newlinechar) ? newlinechar : UInt8(newlinechar),
+        deduplicate_names,
+    )
+
+    chunking_ctx = ChunkingContext(buffersize, nworkers, limit, comment)
+    should_close, io = ChunkedBase._input_to_io(input, use_mmap)
+    try
+        (lexer, lines_skipped_total) = initial_read_and_lex_and_skip!(io, chunking_ctx, settings, escapechar, openquotechar, closequotechar, ignoreemptyrows)
+        # At this point we have skipped `header` rows and subsequent commented rows.
+        # The next row should contain the header and should contain clean enough data to infer
+        # the delimiter.
+        if delim === nothing
+            eols = chunking_ctx.newline_positions
+            delim = _detect_delim(chunking_ctx.bytes, first(eols)+1, last(eols), openquotechar, closequotechar, escapechar, settings.header_at > 0)
+        end
+        options = _create_options(;
+            delim, openquotechar, closequotechar, escapechar, sentinel, groupmark, stripwhitespace,
+            truestrings, falsestrings, dateformat, ignorerepeated, quoted,
+            decimal, ignoreemptyrows, rounding,
+        )
+
+        parsing_ctx = ParsingContext(DataType[], Enums.CSV_TYPE[], Symbol[], escapechar, options)
+        process_header_and_schema_and_finish_row_skip!(parsing_ctx, chunking_ctx, lexer, schema, settings, lines_skipped_total)
+        deduplicate_names && (parsing_ctx.header .= makeunique(parsing_ctx.header))
+        return should_close, parsing_ctx, chunking_ctx, lexer
+    catch
+        should_close && close(io)
+        rethrow()
+    end
+end
+
+"""
+parse_file(input, schema=nothing, consume_ctx::C; kwargs...) where {C<:AbstractConsumeContext} -> Nothing
+parse_file(
+    should_close::Bool,
+    parsing_ctx::ParsingContext,
+    consume_ctx::C,
+    chunking_ctx::ChunkingContext,
+    lexer::Lexer;
+    force::Symbol=:default,
+) where {C<:AbstractConsumeContext} -> Nothing
+
+Parse a CSV input by chunks of size `buffersize` and parse them in parallel using `nworkers` tasks.
+
+Before calling this function, you should define a custom `consume_ctx::C` which is a subtype of `AbstractConsumeContext` and implement a `consume!(::C, ::ParsedPayload)` method.
+Then, the `consume_ctx` is used to consume the parsed data, by internally dispatching on `consume!(::C, ::ParsedPayload)` which are also called in parallel.
+The parsed results can be found in the `results` field `ParsedPayload`, see `TaskResultBuffer` for more information about the format in which the results are stored.
+
+If you need to know the header and / or the schema which will be used to parse the file before creating your `consume_ctx`, you can call `setup_parser`
+and inspect the returned `ParsingContext`, then call `parse_file` with the other objects returned by `setup_parser`.
+
+$_API_DOCS_SHARED
+
+## Returns
+- `Nothing`
+
+$_SEE_ALSO
+- [`setup_parser`](@ref)
+"""
+function parse_file end
+
+function parse_file(
+    input,
+    schema::Union{Nothing,DataType,Base.Callable,Vector{DataType},Dict{Symbol,DataType},Dict{Int,DataType}}=nothing,
+    consume_ctx::AbstractConsumeContext=DebugContext();
+    header::Union{Vector{Symbol},Vector{String},Integer}=true,
+    skipto::Integer=0,
+    limit::Integer=0,
+    # Parsers.Options
+    delim::Union{UInt8,Char,String,Nothing}=',',
+    openquotechar::Union{UInt8,Char}='"',
+    closequotechar::Union{UInt8,Char}='"',
+    escapechar::Union{UInt8,Char}='"',
+    newlinechar::Union{UInt8,Char,Nothing}='\n',
+    sentinel::Union{Missing,Nothing,Vector{String}}=missing,
+    groupmark::Union{Char,UInt8,Nothing}=nothing,
+    stripwhitespace::Bool=false,
+    ignorerepeated::Bool=false,
+    truestrings::Union{Nothing,Vector{String}}=["true", "True", "TRUE", "1", "t", "T"],
+    falsestrings::Union{Nothing,Vector{String}}=["false", "False", "FALSE", "0", "f", "F"],
+    dateformat::Union{String, Dates.DateFormat, Nothing}=nothing,
+    quoted::Bool=true,
+    decimal::Union{Char,UInt8}='.',
+    ignoreemptyrows::Bool=true,
+    rounding::Union{Nothing,RoundingMode}=RoundNearest,
+    #
+    comment::Union{Nothing,String,Char,UInt8}=nothing,
+    validate_type_map::Bool=true,
+    nworkers::Integer=max(1, Threads.nthreads() - 1),
+    # In bytes. This absolutely has to be larger than any single row.
+    # Much safer if any two consecutive rows are smaller than this threshold.
+    buffersize::Integer=(nworkers * 1024 * 1024),
+    force::Symbol=:default,
+    default_colname_prefix::String="COL_",
+    use_mmap::Bool=false,
+    no_quoted_newlines::Bool=false,
+    deduplicate_names::Bool=true,
+)
+    force in (:default, :serial, :parallel) || throw(ArgumentError("`force` argument must be one of (:default, :serial, :parallel)."))
+    (should_close, parsing_ctx, chunking_ctx, lexer) = setup_parser(
+        input, schema;
+        header, skipto, delim, openquotechar, closequotechar, limit, escapechar, newlinechar,
+        sentinel, groupmark, stripwhitespace, truestrings, falsestrings, dateformat, comment,
+        rounding, validate_type_map, default_colname_prefix, buffersize, nworkers,
+        use_mmap, no_quoted_newlines, ignorerepeated, quoted, decimal, ignoreemptyrows,
+        deduplicate_names,
+    )
+    try
+        parse_file(lexer, parsing_ctx, consume_ctx, chunking_ctx, force)
+    finally
+        should_close && close(lexer.io)
+    end
+    return nothing
+end
+
+function parse_file(
+    lexer::Lexer,
+    parsing_ctx::ParsingContext,
+    consume_ctx::AbstractConsumeContext,
+    chunking_ctx::ChunkingContext,
+    force::Symbol=:default,
+)
+    force in (:default, :serial, :parallel) || throw(ArgumentError("`force` argument must be one of (:default, :serial, :parallel)."))
+    schema = parsing_ctx.schema
+    CT = _custom_types(schema)
+
+    nrows = length(chunking_ctx.newline_positions) - 1
+    if ChunkedBase.should_use_parallel(chunking_ctx, force)
+        ntasks = tasks_per_chunk(chunking_ctx)
+        nbuffers = total_result_buffers_count(chunking_ctx)
+        result_buffers = _make_result_buffers(nbuffers, schema, cld(nrows, ntasks))
+        parse_file_parallel(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buffers, CT)
+    else
+        result_buf = TaskResultBuffer(0, parsing_ctx.schema, nrows)
+        parse_file_serial(lexer, parsing_ctx, consume_ctx, chunking_ctx, result_buf, CT)
+    end
+
+    return nothing
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -9,10 +9,12 @@
     @precompile_all_calls begin
         # all calls in this block will be precompiled, regardless of whether
         # they belong to your package or not (on Julia 1.8 and higher)
-        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,DateTime,Bool,String,String,FixedDecimal{Int64,8}], ChunkedCSV.SkipContext())
-        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,DateTime,Bool,String,String,FixedDecimal{Int64,8}], ChunkedCSV.SkipContext(), _force=:parallel)
-        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,GuessDateTime,Bool,String,String,Int], ChunkedCSV.SkipContext())
-        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,GuessDateTime,Bool,String,String,Int], ChunkedCSV.SkipContext(), _force=:parallel)
+        # We use small `buffersize` to make sure that tha parallel parsing codepath
+        # has more than one chunk to work with.
+        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,DateTime,Bool,String,String,FixedDecimal{Int64,8}], ChunkedCSV.SkipContext(), buffersize=64)
+        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,DateTime,Bool,String,String,FixedDecimal{Int64,8}], ChunkedCSV.SkipContext(), force=:parallel, nworkers=2, buffersize=64)
+        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,GuessDateTime,Bool,String,String,Int], ChunkedCSV.SkipContext(), buffersize=64)
+        ChunkedCSV.parse_file(IOBuffer(PRECOMPILE_DATA), [Int,Float64,Date,GuessDateTime,Bool,String,String,Int], ChunkedCSV.SkipContext(), force=:parallel, nworkers=2, buffersize=64)
     end
 end
 

--- a/test/exception_handling.jl
+++ b/test/exception_handling.jl
@@ -11,11 +11,11 @@ end
 
 # Throws when a specified row is greater than the first row of a task buffer
 struct TestThrowingContext <: AbstractConsumeContext
-    tasks::Vector{Task}
-    conds::Vector{ChunkedCSV.TaskCounter}
+    tasks::Base.IdSet{Task}
+    conds::Base.IdSet{ChunkedCSV.TaskCounter}
     throw_row::Int
 end
-TestThrowingContext(throw_row) = TestThrowingContext(Task[], ChunkedCSV.TaskCounter[], throw_row)
+TestThrowingContext(throw_row) = TestThrowingContext(Base.IdSet{Task}(), Base.IdSet{ChunkedCSV.TaskCounter}(), throw_row)
 
 # Throws in the last quarter of the buffer
 struct ThrowingIO <: IO
@@ -29,8 +29,8 @@ Base.eof(io::ThrowingIO) = Base.eof(io.io)
 function ChunkedCSV.consume!(ctx::TestThrowingContext, payload::ChunkedCSV.ParsedPayload)
     t = current_task()
     c = payload.chunking_ctx.counter
-    c in ctx.conds || push!(ctx.conds, c)
-    t in ctx.tasks || push!(ctx.tasks, t)
+    push!(ctx.conds, c)
+    push!(ctx.tasks, t)
     payload.row_num >= ctx.throw_row && error("These contexts are for throwing, and that's all what they do")
     sleep(0.01) # trying to get the task off a fast path to claim everything from the parsing queue
     return nothing
@@ -137,12 +137,12 @@ end
                 """),
                 [Int,Int],
                 throw_ctx,
-                _force=:serial,
+                force=:serial,
                 buffersize=6
             )
             @assert !isempty(throw_ctx.tasks)
-            @test throw_ctx.tasks[1] == current_task()
-            @test throw_ctx.conds[1].exception isa ErrorException
+            @test only(throw_ctx.tasks) == current_task()
+            @test only(throw_ctx.conds).exception isa ErrorException
         end
 
         @testset "parallel" begin
@@ -153,16 +153,19 @@ end
                 [Int,Int],
                 throw_ctx,
                 nworkers=min(3, nthreads()),
-                _force=:parallel,
+                force=:parallel,
                 buffersize=12,
             )
             sleep(0.2)
             @test length(throw_ctx.tasks) == min(3, nthreads())
             @test all(istaskdone, throw_ctx.tasks)
-            @test throw_ctx.conds[1].exception isa CapturedException
-            @test throw_ctx.conds[1].exception.ex.msg == "These contexts are for throwing, and that's all what they do"
-            @test throw_ctx.conds[2].exception isa CapturedException
-            @test throw_ctx.conds[2].exception.ex.msg == "These contexts are for throwing, and that's all what they do"
+            conds = collect(throw_ctx.conds)
+            cond = pop!(conds)
+            @test cond.exception isa CapturedException
+            @test cond.exception.ex.msg == "These contexts are for throwing, and that's all what they do"
+            cond = pop!(conds)
+            @test cond.exception isa CapturedException
+            @test cond.exception.ex.msg == "These contexts are for throwing, and that's all what they do"
         end
     end
 
@@ -173,12 +176,12 @@ end
                 ThrowingIO("a,b\n" * ("1,2\n3,4\n" ^ 10)), # 20 rows total
                 [Int,Int],
                 throw_ctx,
-                _force=:serial,
+                force=:serial,
                 buffersize=6,
             )
             @assert !isempty(throw_ctx.tasks)
-            @test throw_ctx.tasks[1] == current_task()
-            @test throw_ctx.conds[1].exception isa ErrorException
+            @test only(throw_ctx.tasks) == current_task()
+            @test only(throw_ctx.conds).exception isa ErrorException
         end
 
         @testset "parallel" begin
@@ -188,16 +191,20 @@ end
                 [Int,Int],
                 throw_ctx,
                 nworkers=min(3, nthreads()),
-                _force=:parallel,
+                force=:parallel,
                 buffersize=12,
             )
             sleep(0.2)
             @test length(throw_ctx.tasks) == min(3, nthreads())
             @test all(istaskdone, throw_ctx.tasks)
-            @test throw_ctx.conds[1].exception isa CapturedException
-            @test throw_ctx.conds[1].exception.ex.task.result.msg == "That should be enough data for everyone"
-            @test throw_ctx.conds[2].exception isa CapturedException
-            @test throw_ctx.conds[2].exception.ex.task.result.msg == "That should be enough data for everyone"
+
+            conds = collect(throw_ctx.conds)
+            cond = pop!(conds)
+            @test cond.exception isa CapturedException
+            @test cond.exception.ex.task.result.msg == "That should be enough data for everyone"
+            cond = pop!(conds)
+            @test cond.exception isa CapturedException
+            @test cond.exception.ex.task.result.msg == "That should be enough data for everyone"
         end
     end
 end

--- a/test/guess_datetime.jl
+++ b/test/guess_datetime.jl
@@ -18,3 +18,62 @@ macro test_noalloc(e) :(@test(@allocated($(esc(e))) == 0)) end
         end
     end
 end
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01")
+@test res.val == DateTime(2014, 1, 1)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 700)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 780)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.789")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.789")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.7890")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.7890")
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901", rounding=RoundNearest)
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901", rounding=RoundNearest)
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01 12:34:56.78901Z", rounding=RoundNearest)
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)
+@test Parsers.ok(res.code)
+
+res = Parsers.xparse(ChunkedCSV.GuessDateTime, "2014-01-01T12:34:56.78901Z", rounding=RoundNearest)
+@test res.val == DateTime(2014, 1, 1, 12, 34, 56, 789)

--- a/test/misc_tests.jl
+++ b/test/misc_tests.jl
@@ -20,7 +20,7 @@ for alg in (:serial, :parallel)
             """),
             [Int,Int,Int],
             testctx,
-            _force=alg,
+            force=alg,
             buffersize=8,
             use_mmap=true,
         )

--- a/test/simple_file_parsing.jl
+++ b/test/simple_file_parsing.jl
@@ -48,7 +48,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Int,Int],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c]
             @test testctx.schema == [Int, Int, Int]
@@ -69,7 +69,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Float64, Float64],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Float64, Float64]
@@ -88,7 +88,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [FixedDecimal{Int32,2},FixedDecimal{Int64,3},FixedDecimal{UInt128,2}],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c]
             @test testctx.schema == [FixedDecimal{Int32,2},FixedDecimal{Int64,3}, FixedDecimal{UInt128,2}]
@@ -109,7 +109,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Date,Date],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Date, Date]
@@ -140,7 +140,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,GuessDateTime,GuessDateTime,GuessDateTime],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:id, :a, :b, :c]
             @test testctx.schema == [Int, DateTime,DateTime,DateTime]
@@ -163,7 +163,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,DateTime,DateTime,DateTime],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:id, :a, :b, :c]
             @test testctx.schema == [Int, DateTime,DateTime,DateTime]
@@ -184,7 +184,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,DateTime],
                 testctx,
-                _force=alg,
+                force=alg,
                 dateformat=Dates.dateformat"yyyy-mm-dd HH:MM:SS.sss",
             )
             @test testctx.header == [:id, :a]
@@ -204,7 +204,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [String,String],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31]
@@ -222,7 +222,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [String,String,String],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31, Parsers.PosLen31]
@@ -244,7 +244,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 ,,"""),
                 [String,String,String],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31, Parsers.PosLen31]
@@ -271,7 +271,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Char,Char,Char],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c]
             @test testctx.schema == [Char, Char, Char]
@@ -303,7 +303,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Bool,Bool],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Bool, Bool]
@@ -326,7 +326,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int,Int],
                 empty!(testctx),
                 buffersize=6,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Int, Int]
@@ -351,7 +351,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Float64, Float64],
                 testctx,
                 buffersize=10,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Float64, Float64]
@@ -376,7 +376,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [String,String],
                 testctx,
                 buffersize=8,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31]
@@ -413,7 +413,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [String,String],
                 testctx,
                 buffersize=8,
-                _force=alg,
+                force=alg,
                 header=5,
             )
             @test testctx.header == [:a, :b]
@@ -454,7 +454,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int,Int],
                 testctx,
                 buffersize=4,
-                _force=alg,
+                force=alg,
                 header=5,
             )
             @test testctx.header == [:a, :b]
@@ -489,7 +489,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Float64,Float64],
                 testctx,
                 buffersize=8,
-                _force=alg,
+                force=alg,
                 header=5,
             )
             @test testctx.header == [:a, :b]
@@ -519,7 +519,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 testctx,
                 limit=1,
                 header=false,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Int, Int]
@@ -540,7 +540,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 limit=1,
                 header=false,
                 skipto=3,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Int, Int]
@@ -555,7 +555,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 testctx,
                 limit=50,
                 header=false,
-                _force=alg,
+                force=alg,
                 buffersize=10,
             )
             res = collect(testctx)
@@ -575,7 +575,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 limit=1,
                 skipto=2,
                 header=false,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Int, Int]
@@ -595,7 +595,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 testctx,
                 limit=1,
                 header=2,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Int, Int]
@@ -623,7 +623,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg
+                force=alg
             )
             @test testctx.header == [:a, :b]
             @test testctx.schema == [Int, Int]
@@ -651,7 +651,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 buffersize=5,
             )
             @test testctx.header == [:a, :b]
@@ -689,7 +689,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 header=5,
             )
             @test testctx.header == [:a, :b]
@@ -720,7 +720,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 buffersize=5,
                 header=5,
             )
@@ -761,7 +761,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 header=5,
                 skipto=9,
             )
@@ -794,7 +794,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 buffersize=5,
                 header=4,
                 skipto=8,
@@ -836,7 +836,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 header=5,
                 skipto=8,
                 buffersize=5,
@@ -863,7 +863,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int, Int],
                 testctx,
                 comment="#",
-                _force=alg,
+                force=alg,
                 header=false,
                 buffersize=5,
             )
@@ -885,7 +885,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 nothing,
                 testctx,
                 header=false,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31]
@@ -907,7 +907,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 testctx,
                 header=false,
                 skipto=3,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31]
@@ -929,7 +929,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [Int,Int],
                     testctx,
                     header=false,
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:COL_1, :COL_2]
                 @test testctx.schema == [Int, Int]
@@ -949,7 +949,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     testctx,
                     header=false,
                     skipto=3,
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:COL_1, :COL_2]
                 @test testctx.schema == [Int, Int]
@@ -969,7 +969,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 [Int,Int],
                 testctx,
                 header=false,
-                _force=alg,
+                force=alg,
                 default_colname_prefix="#"
             )
             @test testctx.header == [Symbol("#1"), Symbol("#2")]
@@ -983,7 +983,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 nothing,
                 testctx,
                 header=false,
-                _force=alg,
+                force=alg,
                 default_colname_prefix="##"
             )
             @test testctx.header == [Symbol("##1"), Symbol("##2")]
@@ -999,7 +999,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 Dict(:q => Int, :b => Int),
                 testctx,
                 header=[:a, :b, :c],
-                _force=alg,
+                force=alg,
                 validate_type_map=false,
             )
             @test testctx.header == [:a, :b, :c]
@@ -1014,7 +1014,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 Dict(:q => Int, :b => Int),
                 testctx,
                 header=1,
-                _force=alg,
+                force=alg,
                 validate_type_map=false,
             )
             @test testctx.header == [:a, :b, :c]
@@ -1028,7 +1028,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [String,String,String],
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='"',
             )
             @test testctx.header == [:a, :b, Symbol("c\"")]
@@ -1039,7 +1039,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [String,String,String],
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='\\',
             )
             @test testctx.header == [:a, :b, Symbol("c\"")]
@@ -1050,7 +1050,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='"',
             )
             @test testctx.header == [:a, :b, Symbol("c\"")]
@@ -1061,7 +1061,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='\\',
             )
             @test testctx.header == [:a, :b, Symbol("c\"")]
@@ -1072,28 +1072,28 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
     @testset "Empty input ($(io_t), $(alg))" begin
         @testset "Empty lines" begin
             testctx = TestContext()
-            parse_file(io_t("a,b,c\n\n"), nothing, testctx, _force=alg, ignoreemptyrows=false)
+            parse_file(io_t("a,b,c\n\n"), nothing, testctx, force=alg, ignoreemptyrows=false)
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.TooFewColumns | RowStatus.HasColumnIndicators]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\n\n"), nothing, testctx, _force=alg, ignoreemptyrows=true)
+            parse_file(io_t("a,b,c\n\n"), nothing, testctx, force=alg, ignoreemptyrows=true)
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\r\r"), nothing, testctx, _force=alg, ignoreemptyrows=true, newlinechar='\r')
+            parse_file(io_t("a,b,c\r\r"), nothing, testctx, force=alg, ignoreemptyrows=true, newlinechar='\r')
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\r\n\r\n"), nothing, testctx, _force=alg, ignoreemptyrows=true, newlinechar='\n')
+            parse_file(io_t("a,b,c\r\n\r\n"), nothing, testctx, force=alg, ignoreemptyrows=true, newlinechar='\n')
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators]
 
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\r\n\r\n1,2,3\r\n4,5,6"), [Int,Int,Int], testctx, _force=alg, ignoreemptyrows=true)
+            parse_file(io_t("a,b,c\r\n\r\n1,2,3\r\n4,5,6"), [Int,Int,Int], testctx, force=alg, ignoreemptyrows=true)
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators, RowStatus.Ok, RowStatus.Ok]
             @test testctx.results[1].cols[1][2:3] == [1, 4]
@@ -1101,7 +1101,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test testctx.results[1].cols[3][2:3] == [3, 6]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\n\n1,2,3\n4,5,6"), [Int,Int,Int], testctx, _force=alg, ignoreemptyrows=true)
+            parse_file(io_t("a,b,c\n\n1,2,3\n4,5,6"), [Int,Int,Int], testctx, force=alg, ignoreemptyrows=true)
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators, RowStatus.Ok, RowStatus.Ok]
             @test testctx.results[1].cols[1][2:3] == [1, 4]
@@ -1109,7 +1109,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test testctx.results[1].cols[3][2:3] == [3, 6]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\r\r1,2,3\r4,5,6"), [Int,Int,Int], testctx, _force=alg, ignoreemptyrows=true, newlinechar='\r')
+            parse_file(io_t("a,b,c\r\r1,2,3\r4,5,6"), [Int,Int,Int], testctx, force=alg, ignoreemptyrows=true, newlinechar='\r')
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators, RowStatus.Ok, RowStatus.Ok]
             @test testctx.results[1].cols[1][2:3] == [1, 4]
@@ -1117,7 +1117,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test testctx.results[1].cols[3][2:3] == [3, 6]
 
             testctx = TestContext()
-            parse_file(io_t("a,b,c\r\n\r\n1,2,3\r\n\r\n4,5,6"), [Int,Int,Int], testctx, _force=alg, ignoreemptyrows=true)
+            parse_file(io_t("a,b,c\r\n\r\n1,2,3\r\n\r\n4,5,6"), [Int,Int,Int], testctx, force=alg, ignoreemptyrows=true)
             @test testctx.header == [:a, :b, :c]
             @test testctx.results[1].row_statuses == [RowStatus.SkippedRow | RowStatus.HasColumnIndicators, RowStatus.Ok, RowStatus.SkippedRow | RowStatus.HasColumnIndicators, RowStatus.Ok]
             @test testctx.results[1].cols[1][[2,4]] == [1, 4]
@@ -1127,7 +1127,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "no file header, no provided header, no schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t(""), nothing, testctx, force=alg, header=false)
             @test isempty(testctx.results[1].cols)
             @test isempty(testctx.header)
             @test isempty(testctx.schema)
@@ -1135,7 +1135,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "no file header, has provided header, no schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), nothing, testctx, _force=alg, header=[:A, :B])
+            parse_file(io_t(""), nothing, testctx, force=alg, header=[:A, :B])
             @test length(testctx.results[1].cols) == 2
             @test testctx.header == [:A, :B]
             @test testctx.schema == [Parsers.PosLen31, Parsers.PosLen31]
@@ -1143,7 +1143,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "no file header, no provided header, has schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), [Int, String], testctx, _force=alg, header=false)
+            parse_file(io_t(""), [Int, String], testctx, force=alg, header=false)
             @test length(testctx.results[1].cols) == 2
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Int, Parsers.PosLen31]
@@ -1151,7 +1151,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "has file header, has provided header, has schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), [Int, String], testctx, _force=alg, header=[:A, :B])
+            parse_file(io_t(""), [Int, String], testctx, force=alg, header=[:A, :B])
             @test length(testctx.results[1].cols) == 2
             @test testctx.header == [:A, :B]
             @test testctx.schema == [Int, Parsers.PosLen31]
@@ -1159,7 +1159,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "has file header, no provided header, no schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), nothing, testctx, _force=alg, header=true)
+            parse_file(io_t(""), nothing, testctx, force=alg, header=true)
             @test isempty(testctx.results[1].cols)
             @test isempty(testctx.header)
             @test isempty(testctx.schema)
@@ -1167,7 +1167,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "has file header, no provided header, has schema" begin
             testctx = TestContext()
-            parse_file(io_t(""), [Int, String], testctx, _force=alg, header=true)
+            parse_file(io_t(""), [Int, String], testctx, force=alg, header=true)
             @test length(testctx.results[1].cols) == 2
             @test testctx.header == [:COL_1, :COL_2]
             @test testctx.schema == [Int, Parsers.PosLen31]
@@ -1179,7 +1179,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
         # https://www.ietf.org/rfc/rfc4180.txt
         @testset "Each record is located on a separate line, delimited by a line break (CRLF)." begin
             testctx = TestContext()
-            parse_file(io_t("aaa,bbb,ccc\nzzz,yyy,xxx\n"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("aaa,bbb,ccc\nzzz,yyy,xxx\n"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(1, 3), Parsers.PosLen31(13, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(5, 3), Parsers.PosLen31(17, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(9, 3), Parsers.PosLen31(21, 3)]
@@ -1191,7 +1191,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[3]) == 2
 
             testctx = TestContext()
-            parse_file(io_t("aaa,bbb,ccc\r\nzzz,yyy,xxx\r\n"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("aaa,bbb,ccc\r\nzzz,yyy,xxx\r\n"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(1, 3), Parsers.PosLen31(14, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(5, 3), Parsers.PosLen31(18, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(9, 3), Parsers.PosLen31(22, 3)]
@@ -1205,7 +1205,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "The last record in the file may or may not have an ending line break." begin
             testctx = TestContext()
-            parse_file(io_t("aaa,bbb,ccc\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("aaa,bbb,ccc\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(1, 3), Parsers.PosLen31(13, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(5, 3), Parsers.PosLen31(17, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(9, 3), Parsers.PosLen31(21, 3)]
@@ -1217,7 +1217,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[3]) == 2
 
             testctx = TestContext()
-            parse_file(io_t("aaa,bbb,ccc\r\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("aaa,bbb,ccc\r\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(1, 3), Parsers.PosLen31(14, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(5, 3), Parsers.PosLen31(18, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(9, 3), Parsers.PosLen31(22, 3)]
@@ -1238,8 +1238,8 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             should be indicated via the optional "header" parameter of this
             MIME type).""" begin
             testctx = TestContext()
-            parse_file(io_t("field_name,field_name,field_name\naaa,bbb,ccc\nzzz,yyy,xxx"), nothing, testctx, _force=alg)
-            @test testctx.header == [:field_name, :field_name, :field_name]
+            parse_file(io_t("field_name,field_name,field_name\naaa,bbb,ccc\nzzz,yyy,xxx"), nothing, testctx, force=alg)
+            @test testctx.header == [:field_name, :field_name_1, :field_name_2]
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(33+1, 3), Parsers.PosLen31(33+13, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(33+5, 3), Parsers.PosLen31(33+17, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(33+9, 3), Parsers.PosLen31(33+21, 3)]
@@ -1251,8 +1251,8 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[3]) == 2
 
             testctx = TestContext()
-            parse_file(io_t("field_name,field_name,field_name\r\naaa,bbb,ccc\r\nzzz,yyy,xxx"), nothing, testctx, _force=alg)
-            @test testctx.header == [:field_name, :field_name, :field_name]
+            parse_file(io_t("field_name,field_name,field_name\r\naaa,bbb,ccc\r\nzzz,yyy,xxx"), nothing, testctx, force=alg)
+            @test testctx.header == [:field_name, :field_name_1, :field_name_2]
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(34+1, 3), Parsers.PosLen31(34+14, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(34+5, 3), Parsers.PosLen31(34+18, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(34+9, 3), Parsers.PosLen31(34+22, 3)]
@@ -1272,7 +1272,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             record must not be followed by a comma.
             """ begin
             testctx = TestContext()
-            parse_file(io_t("aaa,bbb,ccc"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("aaa,bbb,ccc"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(1, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(5, 3)]
             @test testctx.results[1].cols[3][1:1] == [Parsers.PosLen31(9, 3)]
@@ -1290,7 +1290,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             at all).  If fields are not enclosed with double quotes, then
             double quotes may not appear inside the fields. """ begin
             testctx = TestContext()
-            parse_file(io_t("\"aaa\",\"bbb\",\"ccc\"\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("\"aaa\",\"bbb\",\"ccc\"\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(2, 3), Parsers.PosLen31(19, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(8, 3), Parsers.PosLen31(23, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(14, 3), Parsers.PosLen31(27, 3)]
@@ -1302,7 +1302,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[3]) == 2
 
             testctx = TestContext()
-            parse_file(io_t("\"aaa\",\"bbb\",\"ccc\"\r\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("\"aaa\",\"bbb\",\"ccc\"\r\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(2, 3), Parsers.PosLen31(20, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(8, 3), Parsers.PosLen31(24, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(14, 3), Parsers.PosLen31(28, 3)]
@@ -1318,7 +1318,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             Fields containing line breaks (CRLF), double quotes, and commas
             should be enclosed in double-quotes.""" begin
             testctx = TestContext()
-            parse_file(io_t("\"aaa\",\"b\nbb\",\"ccc\"\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("\"aaa\",\"b\nbb\",\"ccc\"\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(2, 3), Parsers.PosLen31(20, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(8, 4), Parsers.PosLen31(24, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(15, 3), Parsers.PosLen31(28, 3)]
@@ -1330,7 +1330,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[3]) == 2
 
             testctx = TestContext()
-            parse_file(io_t("\"aaa\",\"b\r\nbb\",\"ccc\"\r\nzzz,yyy,xxx"), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("\"aaa\",\"b\r\nbb\",\"ccc\"\r\nzzz,yyy,xxx"), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:2] == [Parsers.PosLen31(2, 3), Parsers.PosLen31(22, 3)]
             @test testctx.results[1].cols[2][1:2] == [Parsers.PosLen31(8, 5), Parsers.PosLen31(26, 3)]
             @test testctx.results[1].cols[3][1:2] == [Parsers.PosLen31(16, 3), Parsers.PosLen31(30, 3)]
@@ -1347,7 +1347,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             appearing inside a field must be escaped by preceding it with
             another double quote. """ begin
             testctx = TestContext()
-            parse_file(io_t("\"aaa\",\"b\"\"bb\",\"ccc\""), nothing, testctx, _force=alg, header=false)
+            parse_file(io_t("\"aaa\",\"b\"\"bb\",\"ccc\""), nothing, testctx, force=alg, header=false)
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(2, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(8, 5, false, true)]
             @test testctx.results[1].cols[3][1:1] == [Parsers.PosLen31(16, 3)]
@@ -1364,7 +1364,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
     @testset "Whitespace ($(io_t), $(alg))" begin
         @testset "Unquoted string fields preserve whitespace" begin
             testctx = TestContext()
-            parse_file(io_t("""a, b\n  foo  , "bar"    \n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n  foo  , "bar"    \n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(6, 7)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(16, 3)]
@@ -1376,7 +1376,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "Whitespace surrounding quoted fields is stripped" begin
             testctx = TestContext()
-            parse_file(io_t("""a, b\n  "foo"  , "bar"    \n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n  "foo"  , "bar"    \n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(9, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(18, 3)]
@@ -1386,7 +1386,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[2]) == 1
 
             testctx = TestContext()
-            parse_file(io_t("""a, b\n"foo"  , "bar"    \n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n"foo"  , "bar"    \n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(7, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(16, 3)]
@@ -1398,7 +1398,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "Newlines inside a quoted field are handled properly" begin
             testctx = TestContext()
-            parse_file(io_t("""a, b\n     "foo", "bar\n     acsas"\n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n     "foo", "bar\n     acsas"\n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(12, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(19, 14)]
@@ -1408,7 +1408,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[2]) == 1
 
             testctx = TestContext()
-            parse_file(io_t("""a, b\n     "foo", "bar\n\r     acsas"\n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n     "foo", "bar\n\r     acsas"\n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(12, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(19, 15)]
@@ -1420,7 +1420,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "Escaped quotes inside a quoted field are handled properly" begin
             testctx = TestContext()
-            parse_file(io_t("""a, b\n"foo"  ,"The cat said, ""meow"" "\n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n"foo"  ,"The cat said, ""meow"" "\n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(7, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(15, 23, false, true)]
@@ -1430,7 +1430,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             @test length(testctx.results[1].cols[2]) == 1
 
             testctx = TestContext()
-            parse_file(io_t("""a, b\n"foo"  ,"The cat said, \\"meow\\" "\n"""), nothing, testctx, _force=alg, escapechar='\\')
+            parse_file(io_t("""a, b\n"foo"  ,"The cat said, \\"meow\\" "\n"""), nothing, testctx, force=alg, escapechar='\\')
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(7, 3)]
             @test testctx.results[1].cols[2][1:1] == [Parsers.PosLen31(15, 23, false, true)]
@@ -1442,7 +1442,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
 
         @testset "Characters outside of a quoted field should be marked as ValueParsingError" begin
             testctx = TestContext()
-            parse_file(io_t("""a, b\n"foo"  , "bar"         234235\n"""), nothing, testctx, _force=alg)
+            parse_file(io_t("""a, b\n"foo"  , "bar"         234235\n"""), nothing, testctx, force=alg)
             @test testctx.header == [:a, :b]
             @test testctx.results[1].cols[1][1:1] == [Parsers.PosLen31(7, 3)]
             @test testctx.strings[1][1][1:1] == ["foo"]
@@ -1464,7 +1464,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                     [Int,Int],
                     testctx,
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,Int]
@@ -1486,7 +1486,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                     [Int,FixedDecimal{Int,4}],
                     testctx,
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,FixedDecimal{Int,4}]
@@ -1511,7 +1511,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                     [Int,GuessDateTime],
                     testctx,
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,DateTime]
@@ -1530,7 +1530,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     parse_file(io_t("a,b,c\r1,2,3\r3,4,4"),
                         [Int,Int,Int],
                         testctx,
-                        _force=alg,
+                        force=alg,
                         newlinechar='\r'
                     )
                     @test testctx.header == [:a, :b, :c]
@@ -1557,7 +1557,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             [Int,String],
             testctx,
             buffersize=8, # last char of the current chunk is a newline
-            _force=alg,
+            force=alg,
             escapechar='"',
         )
         @test testctx.header == [:a, :b]
@@ -1583,7 +1583,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
             [Int,String],
             testctx,
             buffersize=15, # first char of the next chunk is a newline
-            _force=alg,
+            force=alg,
             escapechar='"',
         )
         @test testctx.header == [:a, :b]
@@ -1612,7 +1612,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Float64,Float64,Float64,Float64],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c, :d, :e]
             @test testctx.schema == [Int,Float64,Float64,Float64,Float64]
@@ -1639,7 +1639,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,GuessDateTime,GuessDateTime,GuessDateTime,GuessDateTime],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c, :d, :e]
             @test testctx.schema == [Int,DateTime,DateTime,DateTime,DateTime]
@@ -1662,7 +1662,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,FixedDecimal{Int,4},FixedDecimal{Int,4},FixedDecimal{Int,4},FixedDecimal{Int,4}],
                 testctx,
-                _force=alg,
+                force=alg,
             )
             @test testctx.header == [:a, :b, :c, :d, :e]
             @test testctx.schema == [Int,FixedDecimal{Int,4},FixedDecimal{Int,4},FixedDecimal{Int,4},FixedDecimal{Int,4}]
@@ -1684,7 +1684,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 openquotechar='S',
                 closequotechar='E',
             )
@@ -1710,7 +1710,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 buffersize=8,
                 escapechar='"',
                 header=false,
-                _force=alg,
+                force=alg,
             )
             @test testctx.schema == [Int,Parsers.PosLen31]
             @test length(testctx.results) == 5
@@ -1744,7 +1744,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 nothing,
                 testctx,
                 escapechar='\\',
-                _force=alg,
+                force=alg,
                 delim='|',
             )
             @test testctx.header == [:a, :b]
@@ -1781,7 +1781,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='\\'
             )
             @test testctx.header == [:a, :b]
@@ -1806,7 +1806,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     testctx,
                     buffersize=buffersize,
                     escapechar='"',
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,Parsers.PosLen31]
@@ -1828,7 +1828,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     testctx,
                     buffersize=buffersize,
                     escapechar='\\',
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,Parsers.PosLen31]
@@ -1850,7 +1850,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     testctx,
                     buffersize=buffersize,
                     escapechar='\\',
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b]
                 @test testctx.schema == [Int,Parsers.PosLen31]
@@ -1879,7 +1879,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                         testctx,
                         buffersize=buffersize, # first S in on position 12, second on 24...
                         escapechar='"',
-                        _force=alg,
+                        force=alg,
                     )
                     @test testctx.header == [:a, :b]
                     @test testctx.schema == [Int,Parsers.PosLen31]
@@ -1913,7 +1913,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 header=false,
                 buffersize=8,
                 escapechar='"',
-                _force=alg,
+                force=alg,
             )
             @test testctx.results[1].cols[1] == [Parsers.PosLen31(1, 6)]
             @test testctx.results[2].cols[1] == [Parsers.PosLen31(2, 5, false, true)]
@@ -1931,7 +1931,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 header=false,
                 buffersize=8,
                 escapechar='"',
-                _force=alg,
+                force=alg,
             )
             @test testctx.results[1].cols[1] == [Parsers.PosLen31(1, 5)]
             @test testctx.results[2].cols[1] == [Parsers.PosLen31(2, 5, false, true)]
@@ -1949,7 +1949,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 header=false,
                 buffersize=8,
                 escapechar='\\',
-                _force=alg,
+                force=alg,
             )
             @test testctx.results[1].cols[1] == [Parsers.PosLen31(1, 5)]
             @test testctx.results[2].cols[1] == [Parsers.PosLen31(2, 5, false, true)]
@@ -2024,7 +2024,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='\\',
                 buffersize=10,
             )
@@ -2045,7 +2045,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 nothing,
                 testctx,
-                _force=alg,
+                force=alg,
                 escapechar='\\',
                 buffersize=200,
             )
@@ -2072,7 +2072,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                     [Int,Int,Int],
                     testctx,
-                    _force=alg,
+                    force=alg,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
                 )
                 @test testctx.header == [:a, :b, :c]
@@ -2103,7 +2103,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     """),
                     [Char,Char,Char],
                     testctx,
-                    _force=alg,
+                    force=alg,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
                 )
                 @test testctx.header == [:a, :b, :c]
@@ -2139,7 +2139,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [FixedDecimal{Int32,1}, FixedDecimal{UInt32,2}, FixedDecimal{Int64,3}],
                     testctx,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b, :c]
                 @test testctx.schema == [FixedDecimal{Int32,1}, FixedDecimal{UInt32,2}, FixedDecimal{Int64,3}]
@@ -2182,7 +2182,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [GuessDateTime,GuessDateTime,GuessDateTime],
                     testctx,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b, :c]
                 @test testctx.schema == [DateTime,DateTime,DateTime]
@@ -2225,7 +2225,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [DateTime,DateTime,DateTime],
                     testctx,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b, :c]
                 @test testctx.schema == [DateTime,DateTime,DateTime]
@@ -2270,7 +2270,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [Parsers.SHA1,Parsers.SHA1,Parsers.SHA1],
                     testctx,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b, :c]
                 @test testctx.schema == [Parsers.SHA1,Parsers.SHA1,Parsers.SHA1]
@@ -2314,7 +2314,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                     [UUID,UUID,UUID],
                     testctx,
                     sentinel=isempty(sentinel) ? missing : [sentinel],
-                    _force=alg,
+                    force=alg,
                 )
                 @test testctx.header == [:a, :b, :c]
                 @test testctx.schema == [UUID,UUID,UUID]
@@ -2357,7 +2357,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                         """),
                         [S,S,S],
                         testctx,
-                        _force=alg,
+                        force=alg,
                     )
                     @test testctx.header == [:a, :b, :c]
                     @test testctx.schema == [S,S,S]
@@ -2388,7 +2388,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Int,Int],
                 testctx,
-                _force=alg,
+                force=alg,
                 comment="# ",
             )
             @test testctx.header == [:a, :b, :c]
@@ -2440,7 +2440,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Nothing,Int,Int],
                 testctx,
-                _force=alg,
+                force=alg,
                 comment="# ",
             )
             @test testctx.header == [:b, :c]
@@ -2486,7 +2486,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Nothing,Int],
                 testctx,
-                _force=alg,
+                force=alg,
                 comment="# ",
             )
             @test testctx.header == [:a, :c]
@@ -2531,7 +2531,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Int,Nothing],
                 testctx,
-                _force=alg,
+                force=alg,
                 comment="# ",
             )
             @test testctx.header == [:a, :b]
@@ -2576,7 +2576,7 @@ for (io_t, alg) in Iterators.product((iobuffer, iostream, gzip_stream), (:serial
                 """),
                 [Int,Nothing,Nothing],
                 testctx,
-                _force=alg,
+                force=alg,
                 comment="# ",
             )
             @test testctx.header == [:a]


### PR DESCRIPTION
It provides a better description of the error when one of the column cannot be converted to a symbol, due to the presence of the null byte (\0) or whatever invalid other character.

REF NCDNTS-2221